### PR TITLE
Import blocks from agoodblocks + add CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - name: Verify build output
+        run: |
+          if [ ! -d "build/blocks" ]; then
+            echo "::error::Build directory missing"
+            exit 1
+          fi
+          echo "Build completed successfully"
+          ls -la build/blocks/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - name: Create plugin zip
+        run: |
+          mkdir -p dist
+          zip -r dist/goodblocks.zip \
+            goodblocks.php \
+            inc/ \
+            build/ \
+            -x "*.DS_Store"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/goodblocks.zip
+          generate_release_notes: true

--- a/goodblocks.php
+++ b/goodblocks.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: GoodBlocks
  * Plugin URI: https://agoodsite.se
- * Description: Reusable Gutenberg blocks: Masonry Query, Search Autocomplete, Image Compare, and Feature Card.
+ * Description: Reusable Gutenberg blocks: Masonry Query, Search Autocomplete, Image Compare, Feature Card, Countdown, Quiz, Page List, Double Container, Media Grid, and Mailchimp Signup.
  * Version: 1.0.0
  * Requires at least: 6.4
  * Requires PHP: 8.0
@@ -32,6 +32,13 @@ function goodblocks_register_blocks() {
 		'card-feature',
 		'search-autocomplete',
 		'image-compare',
+		'countdown',
+		'quiz',
+		'page-list',
+		'double-container-text',
+		'media-grid',
+		'media-grid-item',
+		'mailchimp-signup',
 	];
 
 	foreach ( $blocks as $block ) {
@@ -126,6 +133,13 @@ function goodblocks_migrate_namespace( string $from, string $to ): void {
 		'card-feature',
 		'search-autocomplete',
 		'image-compare',
+		'countdown',
+		'quiz',
+		'page-list',
+		'double-container-text',
+		'media-grid',
+		'media-grid-item',
+		'mailchimp-signup',
 	];
 
 	foreach ( $blocks as $block ) {

--- a/src/blocks/countdown/block.json
+++ b/src/blocks/countdown/block.json
@@ -1,0 +1,38 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "goodblocks/countdown",
+    "title": "Countdown",
+    "category": "goodblocks",
+    "icon": "clock",
+    "description": "Display a countdown timer to a specific date and time.",
+    "keywords": [
+        "countdown",
+        "timer",
+        "date"
+    ],
+    "supports": {
+        "html": false,
+        "align": ["wide", "full"]
+    },
+    "attributes": {
+        "targetDate": {
+            "type": "string",
+            "default": ""
+        },
+        "showSeconds": {
+            "type": "boolean",
+            "default": false
+        },
+        "alignment": {
+            "type": "string",
+            "default": "center"
+        }
+    },
+    "textdomain": "goodblocks",
+    "editorScript": "file:./index.js",
+    "editorStyle": "file:./index.css",
+    "style": "file:./style-index.css",
+    "viewScript": "file:./view.js",
+    "render": "file:./render.php"
+}

--- a/src/blocks/countdown/edit.js
+++ b/src/blocks/countdown/edit.js
@@ -1,0 +1,197 @@
+import { __ } from '@wordpress/i18n';
+import {
+	useBlockProps,
+	InspectorControls,
+	BlockControls
+} from '@wordpress/block-editor';
+import {
+	PanelBody,
+	DateTimePicker,
+	ToggleControl,
+	SelectControl,
+	ToolbarGroup,
+	ToolbarButton,
+	Popover
+} from '@wordpress/components';
+import { useState, useEffect } from '@wordpress/element';
+import { calendar } from '@wordpress/icons';
+
+import './editor.scss';
+
+function calculateTimeLeft(targetDate) {
+	if (!targetDate) return null;
+
+	const difference = new Date(targetDate) - new Date();
+
+	if (difference > 0) {
+		return {
+			days: Math.floor(difference / (1000 * 60 * 60 * 24)),
+			hours: Math.floor((difference / (1000 * 60 * 60)) % 24),
+			minutes: Math.floor((difference / 1000 / 60) % 60),
+			seconds: Math.floor((difference / 1000) % 60)
+		};
+	}
+
+	return null;
+}
+
+function CountdownDisplay({ targetDate, showSeconds, alignment }) {
+	const [timeLeft, setTimeLeft] = useState(calculateTimeLeft(targetDate));
+	const [animatingUnits, setAnimatingUnits] = useState({});
+
+	useEffect(() => {
+		if (!targetDate) return;
+
+		const timer = setInterval(() => {
+			const newTimeLeft = calculateTimeLeft(targetDate);
+
+			if (timeLeft && newTimeLeft) {
+				const changes = {};
+				if (timeLeft.days !== newTimeLeft.days) changes.days = true;
+				if (timeLeft.hours !== newTimeLeft.hours) changes.hours = true;
+				if (timeLeft.minutes !== newTimeLeft.minutes) changes.minutes = true;
+				if (timeLeft.seconds !== newTimeLeft.seconds) changes.seconds = true;
+
+				if (Object.keys(changes).length > 0) {
+					setAnimatingUnits(changes);
+					setTimeout(() => setAnimatingUnits({}), 600);
+				}
+			}
+
+			setTimeLeft(newTimeLeft);
+		}, 1000);
+
+		return () => clearInterval(timer);
+	}, [targetDate, timeLeft]);
+
+	if (!targetDate) {
+		return (
+			<div className="countdown-placeholder">
+				<p>{__('Please select a target date', 'goodblocks')}</p>
+			</div>
+		);
+	}
+
+	if (!timeLeft) {
+		return (
+			<div className="countdown-finished">
+				<p>{__('Time\'s up!', 'goodblocks')}</p>
+			</div>
+		);
+	}
+
+	const units = [
+		{ value: timeLeft.days, label: __('Days', 'goodblocks'), key: 'days' },
+		{ value: timeLeft.hours, label: __('Hours', 'goodblocks'), key: 'hours' },
+		{ value: timeLeft.minutes, label: __('Minutes', 'goodblocks'), key: 'minutes' }
+	];
+
+	if (showSeconds) {
+		units.push({ value: timeLeft.seconds, label: __('Seconds', 'goodblocks'), key: 'seconds' });
+	}
+
+	return (
+		<div className={`countdown-display countdown-align-${alignment}`}>
+			{units.map((unit, index) => (
+				<div key={index} className="countdown-unit">
+					<div
+						className={`countdown-number ${animatingUnits[unit.key] ? 'spinning' : ''}`}
+					>
+						{unit.value.toString().padStart(2, '0')}
+					</div>
+					<div className="countdown-label">{unit.label}</div>
+				</div>
+			))}
+		</div>
+	);
+}
+
+export default function Edit({ attributes, setAttributes }) {
+	const {
+		targetDate,
+		showSeconds,
+		alignment
+	} = attributes;
+
+	const [isDatePickerOpen, setIsDatePickerOpen] = useState(false);
+	const blockProps = useBlockProps();
+
+	const formatDisplayDate = (dateString) => {
+		if (!dateString) return __('No date selected', 'goodblocks');
+		try {
+			const date = new Date(dateString);
+			return date.toLocaleDateString() + ' ' + date.toLocaleTimeString();
+		} catch (e) {
+			return __('Invalid date', 'goodblocks');
+		}
+	};
+
+	return (
+		<>
+			<BlockControls>
+				<ToolbarGroup>
+					<ToolbarButton
+						icon={calendar}
+						label={__('Pick Date', 'goodblocks')}
+						onClick={() => setIsDatePickerOpen(!isDatePickerOpen)}
+						isPressed={isDatePickerOpen}
+					>
+						{__('Pick Date', 'goodblocks')}
+					</ToolbarButton>
+				</ToolbarGroup>
+				{isDatePickerOpen && (
+					<Popover
+						placement="bottom-start"
+						onClose={() => setIsDatePickerOpen(false)}
+					>
+						<div style={{ padding: '16px', minWidth: '300px' }}>
+							<h4 style={{ margin: '0 0 12px 0', fontSize: '14px', fontWeight: '600' }}>
+								{__('Select Target Date & Time', 'goodblocks')}
+							</h4>
+							<p style={{ margin: '0 0 12px 0', fontSize: '12px', color: '#666' }}>
+								{__('Current:', 'goodblocks')} {formatDisplayDate(targetDate)}
+							</p>
+							<DateTimePicker
+								currentDate={targetDate}
+								onChange={(newDate) => {
+									setAttributes({ targetDate: newDate });
+									setIsDatePickerOpen(false);
+								}}
+								is12Hour={false}
+							/>
+						</div>
+					</Popover>
+				)}
+			</BlockControls>
+
+			<InspectorControls>
+				<PanelBody title={__('Display Settings', 'goodblocks')}>
+					<SelectControl
+						label={__('Alignment', 'goodblocks')}
+						value={alignment}
+						options={[
+							{ label: __('Left', 'goodblocks'), value: 'left' },
+							{ label: __('Center', 'goodblocks'), value: 'center' },
+							{ label: __('Right', 'goodblocks'), value: 'right' }
+						]}
+						onChange={(value) => setAttributes({ alignment: value })}
+					/>
+					<ToggleControl
+						label={__('Show Seconds', 'goodblocks')}
+						checked={showSeconds}
+						onChange={(value) => setAttributes({ showSeconds: value })}
+						help={__('Display seconds in addition to days, hours, and minutes', 'goodblocks')}
+					/>
+				</PanelBody>
+			</InspectorControls>
+
+			<div {...blockProps}>
+				<CountdownDisplay
+					targetDate={targetDate}
+					showSeconds={showSeconds}
+					alignment={alignment}
+				/>
+			</div>
+		</>
+	);
+}

--- a/src/blocks/countdown/editor.scss
+++ b/src/blocks/countdown/editor.scss
@@ -1,0 +1,5 @@
+.wp-block-goodblocks-countdown {
+	border: 1px dashed rgba(0, 0, 0, 0.1);
+	padding: 1rem;
+	margin: 1rem 0;
+}

--- a/src/blocks/countdown/index.js
+++ b/src/blocks/countdown/index.js
@@ -1,0 +1,8 @@
+import { registerBlockType } from '@wordpress/blocks';
+import './style.scss';
+import Edit from './edit';
+import metadata from './block.json';
+
+registerBlockType(metadata.name, {
+    edit: Edit,
+});

--- a/src/blocks/countdown/render.php
+++ b/src/blocks/countdown/render.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Countdown Block Template
+ *
+ * @var array    $attributes Block attributes.
+ * @var string   $content    Block default content.
+ * @var WP_Block $block      Block instance.
+ */
+
+$target_date = $attributes['targetDate'] ?? '';
+$show_seconds = $attributes['showSeconds'] ?? false;
+$alignment = $attributes['alignment'] ?? 'center';
+
+if (empty($target_date)) {
+    echo '<div class="countdown-placeholder"><p>' . esc_html__('Please select a target date', 'goodblocks') . '</p></div>';
+    return;
+}
+
+$target_timestamp = strtotime($target_date);
+$current_timestamp = current_time('timestamp');
+$difference = $target_timestamp - $current_timestamp;
+
+if ($difference <= 0) {
+    echo '<div class="countdown-finished"><p>' . esc_html__('Time\'s up!', 'goodblocks') . '</p></div>';
+    return;
+}
+
+$days = floor($difference / (60 * 60 * 24));
+$hours = floor(($difference % (60 * 60 * 24)) / (60 * 60));
+$minutes = floor(($difference % (60 * 60)) / 60);
+$seconds = floor($difference % 60);
+
+$block_wrapper_attributes = get_block_wrapper_attributes([
+    'class' => 'countdown-container'
+]);
+?>
+
+<div <?php echo $block_wrapper_attributes; ?>>
+    <div
+        class="countdown-display countdown-align-<?php echo esc_attr($alignment); ?>"
+        data-target-date="<?php echo esc_attr($target_date); ?>"
+        data-show-seconds="<?php echo $show_seconds ? 'true' : 'false'; ?>"
+    >
+        <div class="countdown-unit countdown-days">
+            <div class="countdown-number"><?php echo str_pad($days, 2, '0', STR_PAD_LEFT); ?></div>
+            <div class="countdown-label"><?php esc_html_e('Days', 'goodblocks'); ?></div>
+        </div>
+
+        <div class="countdown-unit countdown-hours">
+            <div class="countdown-number"><?php echo str_pad($hours, 2, '0', STR_PAD_LEFT); ?></div>
+            <div class="countdown-label"><?php esc_html_e('Hours', 'goodblocks'); ?></div>
+        </div>
+
+        <div class="countdown-unit countdown-minutes">
+            <div class="countdown-number"><?php echo str_pad($minutes, 2, '0', STR_PAD_LEFT); ?></div>
+            <div class="countdown-label"><?php esc_html_e('Minutes', 'goodblocks'); ?></div>
+        </div>
+
+        <?php if ($show_seconds): ?>
+        <div class="countdown-unit countdown-seconds">
+            <div class="countdown-number"><?php echo str_pad($seconds, 2, '0', STR_PAD_LEFT); ?></div>
+            <div class="countdown-label"><?php esc_html_e('Seconds', 'goodblocks'); ?></div>
+        </div>
+        <?php endif; ?>
+    </div>
+</div>

--- a/src/blocks/countdown/style.scss
+++ b/src/blocks/countdown/style.scss
@@ -1,0 +1,103 @@
+.wp-block-goodblocks-countdown {
+	.countdown-display {
+		display: flex;
+		gap: 2rem;
+		justify-content: center;
+		flex-wrap: wrap;
+
+		&.countdown-align-left {
+			justify-content: flex-start;
+		}
+
+		&.countdown-align-right {
+			justify-content: flex-end;
+		}
+
+		&.countdown-align-center {
+			justify-content: center;
+		}
+	}
+
+	.countdown-unit {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		min-width: 120px;
+		position: relative;
+	}
+
+	.countdown-number {
+		font-size: 8rem;
+		line-height: 1;
+		margin-bottom: 0.5rem;
+		font-weight: 500;
+
+		@media (max-width: 768px) {
+			font-size: 3rem;
+		}
+
+		@media (max-width: 480px) {
+			font-size: 2.5rem;
+		}
+	}
+
+	.countdown-label {
+		font-size: 2rem;
+		font-weight: 500;
+		letter-spacing: 0.1em;
+		text-align: center;
+
+		@media (max-width: 768px) {
+			font-size: 1rem;
+		}
+
+		@media (max-width: 480px) {
+			font-size: 0.9rem;
+		}
+	}
+
+	.countdown-placeholder,
+	.countdown-finished {
+		text-align: center;
+		padding: 2rem;
+		border: 2px dashed #ddd;
+		border-radius: 8px;
+		background-color: #f9f9f9;
+
+		p {
+			margin: 0;
+			font-size: 1.1rem;
+			color: #666;
+		}
+	}
+
+	.countdown-finished {
+		border-color: #28a745;
+		background-color: #d4edda;
+
+		p {
+			color: #155724;
+			font-weight: 600;
+		}
+	}
+
+	@media (max-width: 768px) {
+		.countdown-display {
+			gap: 1.5rem;
+		}
+
+		.countdown-unit {
+			min-width: 100px;
+		}
+	}
+
+	@media (max-width: 480px) {
+		.countdown-display {
+			gap: 1rem;
+		}
+
+		.countdown-unit {
+			min-width: 80px;
+		}
+	}
+}

--- a/src/blocks/countdown/view.js
+++ b/src/blocks/countdown/view.js
@@ -1,0 +1,90 @@
+/**
+ * Frontend JavaScript for the Countdown block.
+ */
+
+function initCountdown() {
+	const countdownBlocks = document.querySelectorAll('.wp-block-goodblocks-countdown');
+
+	countdownBlocks.forEach(block => {
+		const targetDateElement = block.querySelector('[data-target-date]');
+		if (!targetDateElement) return;
+
+		const targetDate = targetDateElement.getAttribute('data-target-date');
+		const showSeconds = targetDateElement.getAttribute('data-show-seconds') === 'true';
+
+		if (!targetDate) return;
+
+		let previousValues = {};
+		let isFirstLoad = true;
+
+		function animateNumberChange(element, newValue, oldValue) {
+			if (!element) return;
+
+			element.classList.add('spinning');
+
+			setTimeout(() => {
+				element.textContent = newValue.toString().padStart(2, '0');
+				element.classList.remove('spinning');
+
+				if (oldValue !== newValue && !isFirstLoad) {
+					element.classList.add('bounce');
+					setTimeout(() => {
+						element.classList.remove('bounce');
+					}, 300);
+				}
+			}, 200);
+		}
+
+		function updateCountdown() {
+			const now = new Date().getTime();
+			const target = new Date(targetDate).getTime();
+			const difference = target - now;
+
+			if (difference > 0) {
+				const days = Math.floor(difference / (1000 * 60 * 60 * 24));
+				const hours = Math.floor((difference % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+				const minutes = Math.floor((difference % (1000 * 60 * 60)) / (1000 * 60));
+				const seconds = Math.floor((difference % (1000 * 60)) / 1000);
+
+				const daysElement = block.querySelector('.countdown-days .countdown-number');
+				const hoursElement = block.querySelector('.countdown-hours .countdown-number');
+				const minutesElement = block.querySelector('.countdown-minutes .countdown-number');
+				const secondsElement = block.querySelector('.countdown-seconds .countdown-number');
+
+				if (daysElement) {
+					animateNumberChange(daysElement, days, previousValues.days);
+					previousValues.days = days;
+				}
+
+				if (hoursElement) {
+					animateNumberChange(hoursElement, hours, previousValues.hours);
+					previousValues.hours = hours;
+				}
+
+				if (minutesElement) {
+					animateNumberChange(minutesElement, minutes, previousValues.minutes);
+					previousValues.minutes = minutes;
+				}
+
+				if (secondsElement && showSeconds) {
+					animateNumberChange(secondsElement, seconds, previousValues.seconds);
+					previousValues.seconds = seconds;
+				}
+
+				isFirstLoad = false;
+
+			} else {
+				block.innerHTML = '<div class="countdown-finished"><p>Time\'s up!</p></div>';
+			}
+		}
+
+		updateCountdown();
+		setInterval(updateCountdown, 1000);
+	});
+}
+
+if (document.readyState === 'loading') {
+	document.addEventListener('DOMContentLoaded', initCountdown);
+} else {
+	initCountdown();
+}

--- a/src/blocks/double-container-text/block.json
+++ b/src/blocks/double-container-text/block.json
@@ -1,0 +1,92 @@
+{
+	"apiVersion": 3,
+	"name": "goodblocks/double-container-text",
+	"title": "Double Container with Text",
+	"category": "goodblocks",
+	"icon": "columns",
+	"description": "Two side-by-side containers for text and images.",
+	"supports": {
+		"html": false,
+		"align": [
+			"wide",
+			"full"
+		],
+		"color": {
+			"gradient": true
+		},
+		"spacing": {
+			"padding": true,
+			"margin": true
+		}
+	},
+	"attributes": {
+		"align": {
+			"type": "string",
+			"default": "full"
+		},
+		"leftTitle": {
+			"type": "string"
+		},
+		"leftText": {
+			"type": "string"
+		},
+		"leftMedia": {
+			"type": "number"
+		},
+		"leftPosition": {
+			"type": "string",
+			"default": "top-left"
+		},
+		"leftColor": {
+			"type": "string",
+			"default": "#000"
+		},
+		"leftOverlayColor": {
+			"type": "string",
+			"default": "#000000"
+		},
+		"leftDimRatio": {
+			"type": "number",
+			"default": 0
+		},
+		"leftLink": {
+			"type": "string",
+			"default": ""
+		},
+		"rightTitle": {
+			"type": "string"
+		},
+		"rightText": {
+			"type": "string"
+		},
+		"rightMedia": {
+			"type": "number"
+		},
+		"rightPosition": {
+			"type": "string",
+			"default": "top-left"
+		},
+		"rightColor": {
+			"type": "string",
+			"default": "#000"
+		},
+		"rightOverlayColor": {
+			"type": "string",
+			"default": "#000000"
+		},
+		"rightDimRatio": {
+			"type": "number",
+			"default": 0
+		},
+		"rightLink": {
+			"type": "string",
+			"default": ""
+		}
+	},
+	"example": {},
+	"textdomain": "goodblocks",
+	"editorScript": "file:./index.js",
+	"editorStyle": "file:./index.css",
+	"style": "file:./style-index.css",
+	"render": "file:./render.php"
+}

--- a/src/blocks/double-container-text/edit.js
+++ b/src/blocks/double-container-text/edit.js
@@ -1,0 +1,174 @@
+import { __ } from '@wordpress/i18n';
+import {
+    useBlockProps,
+    MediaUpload,
+    MediaUploadCheck,
+    InspectorControls
+} from '@wordpress/block-editor';
+import { Button, PanelBody, TextControl, SelectControl, RangeControl, ColorPalette } from '@wordpress/components';
+import ServerSideRender from '@wordpress/server-side-render';
+import './editor.scss';
+
+const Edit = ({ attributes, setAttributes }) => {
+    const {
+        leftTitle,
+        leftText,
+        leftMedia,
+        leftPosition = 'top-left',
+        leftColor = '#fff',
+        leftOverlayColor = '#000',
+        leftDimRatio = 0,
+        leftLink,
+        rightTitle,
+        rightText,
+        rightMedia,
+        rightPosition = 'top-left',
+        rightColor = '#fff',
+        rightDimRatio = 0,
+        rightOverlayColor = '#000',
+        rightLink
+    } = attributes;
+
+    const positionOptions = [
+        { label: __('Top Left', 'goodblocks'), value: 'top-left' },
+        { label: __('Top Right', 'goodblocks'), value: 'top-right' },
+        { label: __('Bottom Left', 'goodblocks'), value: 'bottom-left' },
+        { label: __('Bottom Right', 'goodblocks'), value: 'bottom-right' },
+    ];
+
+    const colorOptions = [
+        { label: __('White', 'goodblocks'), value: '#fff' },
+        { label: __('Black', 'goodblocks'), value: '#000' },
+    ];
+
+    return (
+        <div {...useBlockProps()}>
+            <InspectorControls>
+                <PanelBody title={__('Left Container Settings', 'goodblocks')} initialOpen={true}>
+                    <TextControl
+                        label={__('Left Title', 'goodblocks')}
+                        value={leftTitle}
+                        onChange={(value) => setAttributes({ leftTitle: value })}
+                    />
+                    <TextControl
+                        label={__('Left Text', 'goodblocks')}
+                        value={leftText}
+                        onChange={(value) => setAttributes({ leftText: value })}
+                    />
+                    <TextControl
+                        label={__('Left Link (URL)', 'goodblocks')}
+                        value={leftLink}
+                        onChange={(value) => setAttributes({ leftLink: value })}
+                        placeholder="https://example.com"
+                    />
+                    <SelectControl
+                        label={__('Text Position', 'goodblocks')}
+                        value={leftPosition}
+                        options={positionOptions}
+                        onChange={(value) => setAttributes({ leftPosition: value })}
+                    />
+                    <SelectControl
+                        label={__('Text Color', 'goodblocks')}
+                        value={leftColor}
+                        options={colorOptions}
+                        onChange={(value) => setAttributes({ leftColor: value })}
+                    />
+                    <RangeControl
+                        label={__('Overlay opacity', 'goodblocks')}
+                        value={leftDimRatio}
+                        onChange={(newDimRatio) =>
+                            setAttributes({ leftDimRatio: newDimRatio })
+                        }
+                        min={0}
+                        max={100}
+                        step={10}
+                        required
+                    />
+                    <ColorPalette
+                        value={leftOverlayColor}
+                        onChange={(newColor) =>
+                            setAttributes({ leftOverlayColor: newColor })
+                        }
+                    />
+                    <MediaUploadCheck>
+                        <MediaUpload
+                            onSelect={(media) => setAttributes({ leftMedia: media?.id || 0 })}
+                            allowedTypes={['image', 'video']}
+                            value={leftMedia}
+                            render={({ open }) => (
+                                <Button onClick={open} variant='secondary'>
+                                    {leftMedia ? __('Replace media', 'goodblocks') : __('Select image or video', 'goodblocks')}
+                                </Button>
+                            )}
+                        />
+                    </MediaUploadCheck>
+                </PanelBody>
+                <PanelBody title={__('Right Container Settings', 'goodblocks')} initialOpen={false}>
+                    <TextControl
+                        label={__('Right Title', 'goodblocks')}
+                        value={rightTitle}
+                        onChange={(value) => setAttributes({ rightTitle: value })}
+                    />
+                    <TextControl
+                        label={__('Right Text', 'goodblocks')}
+                        value={rightText}
+                        onChange={(value) => setAttributes({ rightText: value })}
+                    />
+                    <TextControl
+                        label={__('Right Link (URL)', 'goodblocks')}
+                        value={rightLink}
+                        onChange={(value) => setAttributes({ rightLink: value })}
+                        placeholder="https://example.com"
+                    />
+                    <SelectControl
+                        label={__('Text Position', 'goodblocks')}
+                        value={rightPosition}
+                        options={positionOptions}
+                        onChange={(value) => setAttributes({ rightPosition: value })}
+                    />
+                    <SelectControl
+                        label={__('Text Color', 'goodblocks')}
+                        value={rightColor}
+                        options={colorOptions}
+                        onChange={(value) => setAttributes({ rightColor: value })}
+                    />
+                    <RangeControl
+                        label={__('Overlay opacity', 'goodblocks')}
+                        value={rightDimRatio}
+                        onChange={(newDimRatio) =>
+                            setAttributes({ rightDimRatio: newDimRatio })
+                        }
+                        min={0}
+                        max={100}
+                        step={10}
+                        required
+                    />
+                    <ColorPalette
+                        value={rightOverlayColor}
+                        onChange={(newColor) =>
+                            setAttributes({ rightOverlayColor: newColor })
+                        }
+                    />
+                    <MediaUploadCheck>
+                        <MediaUpload
+                            onSelect={(media) => setAttributes({ rightMedia: media?.id || 0 })}
+                            allowedTypes={['image', 'video']}
+                            value={rightMedia}
+                            render={({ open }) => (
+                                <Button onClick={open} variant='secondary'>
+                                    {rightMedia ? __('Replace media', 'goodblocks') : __('Select image or video', 'goodblocks')}
+                                </Button>
+                            )}
+                        />
+                    </MediaUploadCheck>
+                </PanelBody>
+            </InspectorControls>
+            <ServerSideRender
+                block="goodblocks/double-container-text"
+                attributes={attributes}
+            />
+        </div>
+    );
+}
+
+export default Edit;

--- a/src/blocks/double-container-text/editor.scss
+++ b/src/blocks/double-container-text/editor.scss
@@ -1,0 +1,5 @@
+.wp-block-goodblocks-double-container-text {
+	a {
+		pointer-events: none;
+	}
+}

--- a/src/blocks/double-container-text/index.js
+++ b/src/blocks/double-container-text/index.js
@@ -1,0 +1,9 @@
+import { registerBlockType } from '@wordpress/blocks';
+import './style.scss';
+import Edit from './edit';
+import metadata from './block.json';
+
+registerBlockType(metadata.name, {
+    edit: Edit,
+    save: () => null,
+});

--- a/src/blocks/double-container-text/render.php
+++ b/src/blocks/double-container-text/render.php
@@ -1,0 +1,82 @@
+<?php
+$leftTitle          = $attributes['leftTitle'] ?? '';
+$leftText           = $attributes['leftText'] ?? '';
+$leftMedia          = $attributes['leftMedia'] ?? 0;
+$leftPosition       = $attributes['leftPosition'] ?? 'top-left';
+$leftColor          = $attributes['leftColor'] ?? '#fff';
+$leftOverlayColor   = $attributes['leftOverlayColor'] ?? '#000';
+$leftOverlayOpacity = $attributes['leftDimRatio'] ?? 0;
+$leftOverlayStyle   = 'background-color: ' . esc_attr( $leftOverlayColor ) . '; opacity: ' . esc_attr( $leftOverlayOpacity / 100 ) . ';';
+$leftLink           = $attributes['leftLink'] ?? '';
+
+$rightTitle          = $attributes['rightTitle'] ?? '';
+$rightText           = $attributes['rightText'] ?? '';
+$rightMedia          = $attributes['rightMedia'] ?? 0;
+$rightPosition       = $attributes['rightPosition'] ?? 'top-left';
+$rightColor          = $attributes['rightColor'] ?? '#fff';
+$rightOverlayColor   = $attributes['rightOverlayColor'] ?? '#000';
+$rightOverlayOpacity = $attributes['rightDimRatio'] ?? 0;
+$rightOverlayStyle   = 'background-color: ' . esc_attr( $rightOverlayColor ) . '; opacity: ' . esc_attr( $rightOverlayOpacity / 100 ) . ';';
+$rightLink           = $attributes['rightLink'] ?? '';
+?>
+<div <?php echo get_block_wrapper_attributes(); ?>>
+	<div class="double-text-container">
+		<?php if ( $leftLink ) : ?>
+			<a href="<?php echo esc_url( $leftLink ); ?>"
+				class="double-container-text-link double-container-text-link-left">
+			<?php endif; ?>
+			<div class="double-container-text-left text-pos-<?php echo esc_attr( $leftPosition ); ?>">
+				<div class="double-container-text-overlay" style="<?php echo esc_attr( $leftOverlayStyle ); ?>"></div>
+				<?php if ( $leftMedia ) :
+					$left_mime = get_post_mime_type( $leftMedia );
+					if ( strpos( $left_mime, 'image/' ) === 0 ) : ?>
+						<img src="<?php echo esc_url( wp_get_attachment_image_url( $leftMedia, 'large' ) ); ?>"
+							alt="<?php echo esc_attr( get_post_meta( $leftMedia, '_wp_attachment_image_alt', true ) ); ?>" />
+					<?php elseif ( strpos( $left_mime, 'video/' ) === 0 ) : ?>
+						<video src="<?php echo esc_url( wp_get_attachment_url( $leftMedia ) ); ?>" autoplay muted loop
+							playsinline></video>
+					<?php endif;
+				endif; ?>
+				<div class="double-container-text-content" style="color: <?php echo esc_attr( $leftColor ); ?>">
+					<?php if ( $leftTitle ) : ?>
+						<h4 class="double-container-text-title"><?php echo esc_html( $leftTitle ); ?></h4>
+					<?php endif; ?>
+					<?php if ( $leftText ) : ?>
+						<div class="double-container-text-text"><?php echo esc_html( $leftText ); ?></div>
+					<?php endif; ?>
+				</div>
+			</div>
+			<?php if ( $leftLink ) : ?>
+			</a>
+		<?php endif; ?>
+
+		<?php if ( $rightLink ) : ?>
+			<a href="<?php echo esc_url( $rightLink ); ?>"
+				class="double-container-text-link double-container-text-link-right">
+			<?php endif; ?>
+			<div class="double-container-text-right text-pos-<?php echo esc_attr( $rightPosition ); ?>">
+				<div class="double-container-text-overlay" style="<?php echo esc_attr( $rightOverlayStyle ); ?>"></div>
+				<?php if ( $rightMedia ) :
+					$right_mime = get_post_mime_type( $rightMedia );
+					if ( strpos( $right_mime, 'image/' ) === 0 ) : ?>
+						<img src="<?php echo esc_url( wp_get_attachment_image_url( $rightMedia, 'large' ) ); ?>"
+							alt="<?php echo esc_attr( get_post_meta( $rightMedia, '_wp_attachment_image_alt', true ) ); ?>" />
+					<?php elseif ( strpos( $right_mime, 'video/' ) === 0 ) : ?>
+						<video src="<?php echo esc_url( wp_get_attachment_url( $rightMedia ) ); ?>" autoplay muted loop
+							playsinline></video>
+					<?php endif;
+				endif; ?>
+				<div class="double-container-text-content" style="color: <?php echo esc_attr( $rightColor ); ?>">
+					<?php if ( $rightTitle ) : ?>
+						<h4 class="double-container-text-title"><?php echo esc_html( $rightTitle ); ?></h4>
+					<?php endif; ?>
+					<?php if ( $rightText ) : ?>
+						<div class="double-container-text-text"><?php echo esc_html( $rightText ); ?></div>
+					<?php endif; ?>
+				</div>
+			</div>
+			<?php if ( $rightLink ) : ?>
+			</a>
+		<?php endif; ?>
+	</div>
+</div>

--- a/src/blocks/double-container-text/style.scss
+++ b/src/blocks/double-container-text/style.scss
@@ -1,0 +1,107 @@
+.wp-block-goodblocks-double-container-text {
+
+    .double-text-container {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+
+        @media(max-width: 768px) {
+            grid-template-columns: 1fr;
+        }
+    }
+
+    &+.wp-block-goodblocks-double-container-text {
+        margin-top: 0 !important;
+    }
+
+    &:has(+.wp-block-goodblocks-double-container-text) {
+        margin-bottom: 0 !important;
+    }
+
+    .double-container-text-overlay {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        z-index: 1;
+    }
+
+    margin-top: 2rem !important;
+    margin-bottom: 2rem !important;
+
+    .double-container-text-left,
+    .double-container-text-right {
+        position: relative;
+        padding: 0;
+        min-height: 100vh;
+        display: flex;
+        align-items: stretch;
+        justify-content: stretch;
+        overflow: hidden;
+    }
+
+    img,
+    video {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        display: block;
+        position: absolute;
+        top: 0;
+        left: 0;
+    }
+
+    .double-container-text-title,
+    .double-container-text-text {
+        position: relative;
+        z-index: 2;
+        margin: 0;
+    }
+
+    .double-container-text-title {
+        font-size: 1.25rem;
+        margin-bottom: 3px;
+    }
+
+    .double-container-text-text {
+        font-size: 1rem;
+    }
+
+    .double-container-text-content {
+        position: absolute;
+        z-index: 2;
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+        padding: 40px;
+    }
+
+    .text-pos-top-left .double-container-text-content {
+        top: 0;
+        left: 0;
+        align-items: flex-start;
+        justify-content: flex-start;
+    }
+    .text-pos-top-right .double-container-text-content {
+        top: 0;
+        right: 0;
+        left: auto;
+        align-items: flex-end;
+        justify-content: flex-start;
+    }
+    .text-pos-bottom-left .double-container-text-content {
+        bottom: 0;
+        left: 0;
+        top: auto;
+        align-items: flex-start;
+        justify-content: flex-end;
+    }
+    .text-pos-bottom-right .double-container-text-content {
+        bottom: 0;
+        right: 0;
+        left: auto;
+        top: auto;
+        align-items: flex-end;
+        justify-content: flex-end;
+    }
+}

--- a/src/blocks/mailchimp-signup/block.json
+++ b/src/blocks/mailchimp-signup/block.json
@@ -1,0 +1,44 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "goodblocks/mailchimp-signup",
+	"version": "0.1.0",
+	"title": "Mailchimp Signup Form",
+	"category": "widgets",
+	"icon": "email",
+	"description": "A simple Mailchimp signup form block with email field, title, and text.",
+	"example": {},
+	"supports": {
+		"html": false,
+		"color": {
+			"background": true,
+			"text": true
+		},
+        "align": [
+            "wide",
+            "full"
+        ],
+        "default": {
+            "align": "full"
+        }
+	},
+	"attributes": {
+		"title": {
+			"type": "string",
+			"default": "Subscribe to our newsletter"
+		},
+		"text": {
+			"type": "string",
+			"default": "Enter your email address to receive our newsletters."
+		},
+		"listLink": {
+			"type": "string",
+			"default": ""
+		}
+	},
+    "textdomain": "goodblocks",
+    "editorScript": "file:./index.js",
+    "editorStyle": "file:./index.css",
+    "style": "file:./style-index.css",
+    "render": "file:./render.php"
+}

--- a/src/blocks/mailchimp-signup/edit.js
+++ b/src/blocks/mailchimp-signup/edit.js
@@ -1,0 +1,53 @@
+import { __ } from '@wordpress/i18n';
+import { useBlockProps, RichText, InspectorControls } from '@wordpress/block-editor';
+import { TextControl, PanelBody } from '@wordpress/components';
+import './editor.scss';
+
+export default function Edit({ attributes, setAttributes }) {
+	const { title, text, listLink } = attributes;
+
+	return (
+		<div
+			{...useBlockProps()}
+		>
+			<InspectorControls>
+				<PanelBody title={__('Settings', 'goodblocks')}>
+					<TextControl
+						label={__('Mailchimp Form Action URL', 'goodblocks')}
+						value={listLink}
+						onChange={(value) => setAttributes({ listLink: value })}
+						placeholder="https://example.com/list-link"
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<div class="content-wrapper">
+				<RichText
+					tagName="h2"
+					value={title}
+					onChange={(value) => setAttributes({ title: value })}
+					placeholder={__('Title...', 'goodblocks')}
+					allowedFormats={[]}
+				/>
+				<RichText
+					tagName="p"
+					value={text}
+					onChange={(value) => setAttributes({ text: value })}
+					placeholder={__('Description...', 'goodblocks')}
+					allowedFormats={[]}
+				/>
+				<form className="mailchimp-signup-form" onSubmit={e => e.preventDefault()}>
+					<input
+						type="email"
+						name="EMAIL"
+						placeholder={__('Email', 'goodblocks')}
+						required
+						disabled
+					/>
+					<button type="submit" className="wp-block-button__link" disabled>
+						{__('Subscribe', 'goodblocks')}
+					</button>
+				</form>
+			</div>
+		</div>
+	);
+}

--- a/src/blocks/mailchimp-signup/editor.scss
+++ b/src/blocks/mailchimp-signup/editor.scss
@@ -1,0 +1,5 @@
+.wp-block-goodblocks-mailchimp-signup {
+	input[type="email"] {
+		padding: 8px 16px !important;
+	}
+}

--- a/src/blocks/mailchimp-signup/index.js
+++ b/src/blocks/mailchimp-signup/index.js
@@ -1,0 +1,8 @@
+import { registerBlockType } from '@wordpress/blocks';
+import './style.scss';
+import Edit from './edit';
+import metadata from './block.json';
+
+registerBlockType(metadata.name, {
+	edit: Edit,
+});

--- a/src/blocks/mailchimp-signup/render.php
+++ b/src/blocks/mailchimp-signup/render.php
@@ -1,0 +1,27 @@
+<?php
+$title            = isset( $attributes['title'] ) ? $attributes['title'] : __( 'Subscribe to our newsletter', 'goodblocks' );
+$text             = isset( $attributes['text'] ) ? $attributes['text'] : __( 'Enter your email address to receive our newsletters.', 'goodblocks' );
+$mailchimp_action = ! empty( $attributes['listLink'] ) ? $attributes['listLink'] : '';
+?>
+
+<div <?php echo get_block_wrapper_attributes(); ?>>
+	<div class="content-wrapper">
+		<?php if ( ! empty( $title ) ) : ?>
+			<h2><?php echo esc_html( $title ); ?></h2>
+		<?php endif; ?>
+		<?php if ( ! empty( $text ) ) : ?>
+			<p><?php echo esc_html( $text ); ?></p>
+		<?php endif; ?>
+		<form action="<?php echo esc_url( $mailchimp_action ); ?>" method="post"
+			name="mc-embedded-subscribe-form" class="validate form-search" novalidate>
+			<input type="email" name="EMAIL" placeholder="<?php esc_attr_e( 'Email', 'goodblocks' ); ?>" required
+				autocomplete="on" />
+			<div style="position: absolute; left: -5000px;" aria-hidden="true">
+				<input type="text" name="b_honeypot" tabindex="-1" value="">
+			</div>
+			<input type="submit" value="<?php esc_html_e( 'Subscribe', 'goodblocks' ); ?>" name="subscribe"
+				class="btn btn-primary">
+			</input>
+		</form>
+	</div>
+</div>

--- a/src/blocks/mailchimp-signup/style.scss
+++ b/src/blocks/mailchimp-signup/style.scss
@@ -1,0 +1,46 @@
+.wp-block-goodblocks-mailchimp-signup {
+	.content-wrapper {
+		padding: 80px;
+		margin: 0 auto;
+		max-width: 960px;
+		text-align: center;
+
+		h2 {
+			margin-bottom: 1rem;
+		}
+
+		form {
+			margin-top: 2rem;
+			display: flex;
+
+			input[type="email"] {
+				width: 80%;
+				padding: 16px 20px;
+				border: 0;
+				background: white;
+				border-radius: 0;
+				margin-bottom: 0;
+			}
+
+			input[type="submit"] {
+				width: 20%;
+				margin-left: 10px;
+			}
+
+			@media(max-width: 768px) {
+				flex-direction: column;
+
+				input[type="email"] {
+					width: 100%;
+				}
+
+				input[type="submit"] {
+					max-width: 100%;
+					width: 100%;
+					margin-left: 0;
+					margin-top: 10px;
+				}
+			}
+		}
+	}
+}

--- a/src/blocks/media-grid-item/block.json
+++ b/src/blocks/media-grid-item/block.json
@@ -1,0 +1,95 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "goodblocks/media-grid-item",
+    "title": "Media Grid Item",
+    "category": "goodblocks",
+    "icon": "image-flip-horizontal",
+    "description": "Individual item for media grid with background image/video and text.",
+    "keywords": [
+        "grid",
+        "media",
+        "item"
+    ],
+    "parent": [
+        "goodblocks/media-grid"
+    ],
+    "supports": {
+        "html": false,
+        "reusable": false,
+        "color": {
+            "text": true,
+            "background": true,
+            "gradients": false
+        },
+        "spacing": {
+            "padding": false,
+            "margin": false
+        },
+        "typography": {
+            "fontSize": false,
+            "lineHeight": false
+        }
+    },
+    "attributes": {
+        "title": {
+            "type": "string",
+            "default": "Title here"
+        },
+        "text": {
+            "type": "string",
+            "default": "Text here..."
+        },
+        "backgroundMedia": {
+            "type": "object",
+            "default": {
+                "type": "image",
+                "url": "",
+                "id": null
+            }
+        },
+        "textPosition": {
+            "type": "string",
+            "default": "flex-start"
+        },
+        "overlayOpacity": {
+            "type": "number",
+            "default": 0.3
+        },
+        "link": {
+            "type": "string",
+            "default": ""
+        },
+        "size": {
+            "type": "string",
+            "default": "normal"
+        },
+        "gridColumn": {
+            "type": "string",
+            "default": ""
+        },
+        "gridRow": {
+            "type": "string",
+            "default": ""
+        },
+        "imageType": {
+            "type": "string",
+            "enum": ["overlayOnHover", "imageOnHover", "none", "alwaysOverlay"],
+            "default": "overlayOnHover"
+        },
+        "textType": {
+            "type": "string",
+            "default": "titleOnTop"
+        },
+        "titleSize": {
+            "type": "string",
+            "enum": ["normal", "large"],
+            "default": "normal"
+        }
+    },
+    "textdomain": "goodblocks",
+    "editorScript": "file:./index.js",
+    "editorStyle": "file:./index.css",
+    "style": "file:./style-index.css",
+    "render": "file:./render.php"
+}

--- a/src/blocks/media-grid-item/edit.js
+++ b/src/blocks/media-grid-item/edit.js
@@ -1,0 +1,238 @@
+import { __ } from '@wordpress/i18n';
+import {
+	useBlockProps,
+	RichText,
+	BlockControls,
+	MediaUpload,
+	MediaUploadCheck,
+	LinkControl,
+	InspectorControls
+} from '@wordpress/block-editor';
+import {
+	ToolbarGroup,
+	ToolbarButton,
+	Popover,
+	RangeControl,
+	PanelBody,
+	TextControl,
+	SelectControl
+} from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { link as linkIcon, image, video } from '@wordpress/icons';
+
+import './editor.scss';
+
+export default function Edit({ attributes, setAttributes }) {
+	const {
+		title,
+		text,
+		backgroundMedia,
+		overlayOpacity,
+		type,
+		imageType,
+		textType,
+		link: itemLink,
+		height,
+		gridColumn,
+		gridRow,
+		textPosition,
+		titleSize
+	} = attributes;
+
+	const [isLinkPickerOpen, setIsLinkPickerOpen] = useState(false);
+
+	const blockProps = useBlockProps({
+		className: 'media-grid-item',
+		'data-image-type': imageType || type || 'overlayOnHover'
+	});
+
+	return (
+		<>
+			<BlockControls>
+				<ToolbarGroup>
+					<MediaUploadCheck>
+						<MediaUpload
+							onSelect={(media) => {
+								setAttributes({
+									backgroundMedia: {
+										type: media.type === 'video' ? 'video' : 'image',
+										url: media.url,
+										id: media.id
+									}
+								});
+							}}
+							allowedTypes={['image', 'video']}
+							value={backgroundMedia?.id}
+							render={({ open }) => (
+								<>
+									<ToolbarButton
+										icon={backgroundMedia?.type === 'video' ? video : image}
+										onClick={open}
+										label={backgroundMedia?.url
+											? __('Change Media', 'goodblocks')
+											: __('Add Media', 'goodblocks')
+										}
+									/>
+									{backgroundMedia?.url && (
+										<ToolbarButton
+											onClick={() => setAttributes({
+												backgroundMedia: {
+													type: 'image',
+													url: '',
+													id: null
+												}
+											})}
+											label={__('Remove Media', 'goodblocks')}
+										>
+											{__('Remove', 'goodblocks')}
+										</ToolbarButton>
+									)}
+								</>
+							)}
+						/>
+					</MediaUploadCheck>
+					<ToolbarButton
+						icon={linkIcon}
+						onClick={() => setIsLinkPickerOpen(true)}
+						isActive={!!itemLink}
+						label={itemLink ? __('Edit Link', 'goodblocks') : __('Add Link', 'goodblocks')}
+					/>
+				</ToolbarGroup>
+				{isLinkPickerOpen && (
+					<Popover
+						position="bottom center"
+						onClose={() => setIsLinkPickerOpen(false)}
+					>
+						<LinkControl
+							value={{ url: itemLink || '' }}
+							onChange={({ url }) => setAttributes({ link: url })}
+							onRemove={() => {
+								setAttributes({ link: '' });
+								setIsLinkPickerOpen(false);
+							}}
+							forceIsEditingLink
+						/>
+					</Popover>
+				)}
+			</BlockControls>
+
+			<InspectorControls>
+				<PanelBody title={__('Item settings', 'goodblocks')}>
+					<RangeControl
+						label={__('Overlay Opacity', 'goodblocks')}
+						value={overlayOpacity}
+						onChange={(value) => setAttributes({ overlayOpacity: value })}
+						min={0}
+						max={1}
+						step={0.1}
+					/>
+					<SelectControl
+						label={__('Image type', 'goodblocks')}
+						value={imageType || type || 'none'}
+						options={[
+							{ label: __('Overlay on Hover', 'goodblocks'), value: 'overlayOnHover' },
+							{ label: __('Image on hover', 'goodblocks'), value: 'imageOnHover' },
+							{ label: __('Always Overlay', 'goodblocks'), value: 'alwaysOverlay' },
+							{ label: __('None', 'goodblocks'), value: 'none' }
+						]}
+						onChange={(value) => setAttributes({ imageType: value })}
+					/>
+					<SelectControl
+						label={__('Text type', 'goodblocks')}
+						value={textType}
+						options={[
+							{ label: __('Title on Top', 'goodblocks'), value: 'titleOnTop' },
+							{ label: __('Title at Bottom', 'goodblocks'), value: 'titleAtBottom' }
+						]}
+						onChange={(value) => setAttributes({ textType: value })}
+					/>
+					<SelectControl
+						label={__('Text position', 'goodblocks')}
+						value={textPosition}
+						options={[
+							{ label: __('Top', 'goodblocks'), value: 'flex-start' },
+							{ label: __('Center', 'goodblocks'), value: 'center' },
+							{ label: __('Bottom', 'goodblocks'), value: 'flex-end' }
+						]}
+						onChange={(value) => setAttributes({ textPosition: value })}
+					/>
+					<SelectControl
+						label={__('Title size', 'goodblocks')}
+						value={titleSize}
+						options={[
+							{ label: __('Normal', 'goodblocks'), value: 'normal' },
+							{ label: __('Large', 'goodblocks'), value: 'large' }
+						]}
+						onChange={(value) => setAttributes({ titleSize: value })}
+					/>
+				</PanelBody>
+
+				<PanelBody title={__('Custom grid position', 'goodblocks')} initialOpen={false}>
+					<TextControl
+						label={__('Grid column (e.g. 1 / 3 or span 2)', 'goodblocks')}
+						value={gridColumn}
+						onChange={(value) => setAttributes({ gridColumn: value })}
+						placeholder={__('Leave empty for auto', 'goodblocks')}
+						help={__('CSS grid-column value for custom layouts', 'goodblocks')}
+					/>
+					<TextControl
+						label={__('Grid row (e.g. 1 / 3 or span 2)', 'goodblocks')}
+						value={gridRow}
+						onChange={(value) => setAttributes({ gridRow: value })}
+						placeholder={__('Leave empty for auto', 'goodblocks')}
+						help={__('CSS grid-row value for custom layouts', 'goodblocks')}
+					/>
+				</PanelBody>
+			</InspectorControls>
+
+			<div
+				{...blockProps}
+				style={{
+					'--overlay-opacity': overlayOpacity,
+					...(gridColumn && { gridColumn }),
+					...(gridRow && { gridRow })
+				}}
+			>
+				{backgroundMedia.url && (
+					<div className="media-background">
+						{backgroundMedia.type === 'video' ? (
+							<video
+								src={backgroundMedia.url}
+								muted
+								loop
+								playsInline
+							/>
+						) : (
+							<img
+								src={backgroundMedia.url}
+								alt=""
+							/>
+						)}
+					</div>
+				)}
+				<div className="content-overlay" style={{ justifyContent: textPosition }}>
+					<RichText
+						tagName="h3"
+						value={title}
+						onChange={(value) => setAttributes({ title: value })}
+						placeholder={__('Enter title...', 'goodblocks')}
+						className={`item-title ${titleSize === 'large' ? 'h2' : ''}`}
+						allowedFormats={['core/bold', 'core/italic']}
+						__unstableAllowHTML
+						style={{ order: textType === 'titleOnTop' ? 1 : 2 }}
+					/>
+					<RichText
+						tagName="p"
+						value={text}
+						onChange={(value) => setAttributes({ text: value })}
+						placeholder={__('Enter text...', 'goodblocks')}
+						className="item-text"
+						allowedFormats={['core/bold', 'core/italic', 'core/link']}
+						__unstableAllowHTML
+						style={{ order: textType === 'titleOnTop' ? 2 : 1 }}
+					/>
+				</div>
+			</div>
+		</>
+	);
+}

--- a/src/blocks/media-grid-item/editor.scss
+++ b/src/blocks/media-grid-item/editor.scss
@@ -1,0 +1,75 @@
+.wp-block-goodblocks-media-grid-item {
+	position: relative;
+	min-height: var(--item-height, 300px);
+	border: 1px dashed #ccc;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	overflow: hidden;
+
+	&:hover {
+		border-color: #007cba;
+	}
+
+	.media-background {
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		z-index: 1;
+
+		img, video {
+			width: 100%;
+			height: 100%;
+			object-fit: cover;
+		}
+	}
+
+	.content-overlay {
+		position: relative;
+		z-index: 3;
+		padding: 20px;
+		width: 100%;
+
+		&::before {
+			content: '';
+			position: absolute;
+			top: 0;
+			left: 0;
+			right: 0;
+			bottom: 0;
+			background: rgba(0, 0, 0, var(--overlay-opacity, 0.4));
+			z-index: -1;
+		}
+	}
+
+	.item-title {
+		margin: 0;
+		font-size: clamp(1rem, 2.5vw, 2rem);
+		font-weight: 700;
+
+		&:focus {
+			outline: 2px solid #007cba;
+			outline-offset: 2px;
+		}
+	}
+
+	&:not(:has(.media-background)) {
+		background: #d5d5d5;
+
+		.content-overlay::before {
+			display: none;
+		}
+
+		.item-title {
+			text-shadow: none;
+		}
+	}
+}
+
+.wp-block-goodblocks-media-grid {
+	.wp-block-goodblocks-media-grid-item {
+		margin: 0;
+	}
+}

--- a/src/blocks/media-grid-item/index.js
+++ b/src/blocks/media-grid-item/index.js
@@ -1,0 +1,8 @@
+import { registerBlockType } from '@wordpress/blocks';
+import './style.scss';
+import Edit from './edit';
+import metadata from './block.json';
+
+registerBlockType(metadata.name, {
+    edit: Edit,
+});

--- a/src/blocks/media-grid-item/render.php
+++ b/src/blocks/media-grid-item/render.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Media Grid Item Block Template
+ *
+ * @var array    $attributes Block attributes.
+ * @var string   $content    Block default content.
+ * @var WP_Block $block      Block instance.
+ */
+
+$title            = $attributes['title'] ?? 'Default Title';
+$text             = $attributes['text'] ?? '';
+$background_media = $attributes['backgroundMedia'] ?? [];
+$overlay_opacity  = $attributes['overlayOpacity'] ?? 0.3;
+$text_position    = $attributes['textPosition'] ?? 'flex-start';
+$text_type        = $attributes['textType'] ?? 'titleOnTop';
+$image_type       = $attributes['imageType'] ?? 'overlayOnHover';
+$link             = $attributes['link'] ?? '';
+$grid_column      = $attributes['gridColumn'] ?? '';
+$grid_row         = $attributes['gridRow'] ?? '';
+$title_size       = $attributes['titleSize'] ?? 'normal';
+
+$has_link = ! empty( $link );
+$style_vars = [
+	'--overlay-opacity: ' . esc_attr( $overlay_opacity )
+];
+
+if ( ! empty( $grid_column ) ) {
+	$style_vars[] = 'grid-column: ' . esc_attr( $grid_column );
+}
+if ( ! empty( $grid_row ) ) {
+	$style_vars[] = 'grid-row: ' . esc_attr( $grid_row );
+}
+
+$inline_style = implode( '; ', $style_vars );
+
+$content_overlay_style = 'justify-content: ' . esc_attr( $text_position );
+
+$block_wrapper_attributes = get_block_wrapper_attributes( [
+	'style'           => $inline_style,
+	'data-image-type' => esc_attr( $image_type )
+] );
+$tag                      = $has_link ? 'a' : 'div';
+$extra_attrs              = $has_link ? ' href="' . esc_url( $link ) . '"' : '';
+?>
+
+<<?php echo $tag; ?><?php echo $extra_attrs; ?> <?php echo $block_wrapper_attributes; ?>>
+	<?php if ( ! empty( $background_media['url'] ) ) : ?>
+		<div class="media-background">
+			<?php if ( $background_media['type'] === 'video' ) : ?>
+				<video src="<?php echo esc_url( $background_media['url'] ); ?>" muted loop playsinline></video>
+			<?php else : ?>
+				<img src="<?php echo esc_url( $background_media['url'] ); ?>" alt="">
+			<?php endif; ?>
+		</div>
+	<?php endif; ?>
+
+	<div class="content-overlay" style="<?php echo $content_overlay_style; ?>">
+		<?php
+		$title_order   = ( $text_type === 'titleOnTop' ) ? '1' : '2';
+		$text_order    = ( $text_type === 'titleOnTop' ) ? '2' : '1';
+		$title_classes = 'item-title';
+		if ( $title_size === 'large' ) {
+			$title_classes .= ' h2';
+		}
+
+		$display_title = $title;
+		$display_text  = $text;
+		?>
+		<h3 class="<?php echo esc_attr( $title_classes ); ?>" style="order: <?php echo esc_attr( $title_order ); ?>">
+			<?php echo wp_kses_post( $display_title ); ?>
+		</h3>
+		<?php if ( ! empty( $display_text ) ) : ?>
+			<p class="item-text" style="order: <?php echo esc_attr( $text_order ); ?>">
+				<?php echo wp_kses_post( $display_text ); ?>
+			</p>
+		<?php endif; ?>
+	</div>
+</<?php echo $tag; ?>>

--- a/src/blocks/media-grid-item/style.scss
+++ b/src/blocks/media-grid-item/style.scss
@@ -1,0 +1,133 @@
+.wp-block-goodblocks-media-grid-item {
+	position: relative;
+	overflow: hidden;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	min-height: var(--item-height, 300px);
+	height: 100%;
+	text-decoration: none;
+	color: inherit;
+
+	.media-background {
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		z-index: 1;
+
+		img,
+		video {
+			width: 100%;
+			height: 100%;
+			object-fit: cover;
+		}
+	}
+
+	.content-overlay {
+		position: relative;
+		z-index: 3;
+		padding: 1.5rem;
+		width: 100%;
+		height: 100%;
+		display: flex;
+		text-align: left;
+		flex-direction: column;
+		color: #fff;
+
+		&.flex-start {
+			justify-content: flex-start;
+		}
+
+		&.center {
+			justify-content: center;
+		}
+
+		&.flex-end {
+			justify-content: flex-end;
+		}
+
+		p {
+			margin-bottom: 0;
+		}
+
+		&::before {
+			content: '';
+			position: absolute;
+			top: 0;
+			left: 0;
+			right: 0;
+			bottom: 0;
+			background: rgba(0, 0, 0, var(--overlay-opacity, 0.4));
+			z-index: -1;
+		}
+
+		@media(max-width: 768px) {
+			padding: 20px;
+		}
+	}
+
+	.item-title {
+		margin-bottom: 0 !important;
+		margin-top: 0;
+		color: inherit;
+
+		&.h2 {
+			margin-bottom: 0.5rem !important;
+		}
+	}
+
+	&:not(:has(.media-background)) {
+
+		.content-overlay::before {
+			display: none;
+		}
+
+		.item-title {
+			text-shadow: none;
+		}
+	}
+
+	&[data-image-type="overlayOnHover"] {
+		.content-overlay::before {
+			opacity: 0;
+			transition: opacity 0.3s ease;
+		}
+
+		&:hover .content-overlay::before {
+			opacity: 1;
+		}
+	}
+
+	&[data-image-type="imageOnHover"] {
+		.content-overlay::before {
+			opacity: 0;
+		}
+
+		.media-background {
+			opacity: 0;
+			transition: opacity 0.3s ease;
+		}
+
+		&:hover .media-background {
+			opacity: 1;
+		}
+	}
+
+	&[data-image-type="alwaysOverlay"] {
+		.content-overlay::before {
+			opacity: 1;
+		}
+
+		&:hover .content-overlay::before {
+			opacity: 1;
+		}
+	}
+
+	&[data-image-type="none"] {
+		.content-overlay::before {
+			display: none;
+		}
+	}
+}

--- a/src/blocks/media-grid/block.json
+++ b/src/blocks/media-grid/block.json
@@ -1,0 +1,60 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "goodblocks/media-grid",
+    "title": "Media Grid",
+    "category": "goodblocks",
+    "icon": "layout",
+    "description": "A flexible grid container with background images/videos and text, featuring bento layout options.",
+    "allowedBlocks": [
+        "goodblocks/media-grid-item"
+    ],
+    "supports": {
+        "align": [
+            "wide",
+            "full"
+        ]
+    },
+    "attributes": {
+        "columns": {
+            "type": "number",
+            "default": 3
+        },
+        "gap": {
+            "type": "number",
+            "default": 0
+        },
+        "layout": {
+            "type": "string",
+            "enum": [
+                "grid",
+                "bento-large-left",
+                "bento-large-right",
+                "bento-large-top",
+                "mosaic",
+                "custom"
+            ]
+        },
+        "tabletColumns": {
+            "type": "number",
+            "default": 2
+        },
+        "mobileColumns": {
+            "type": "number",
+            "default": 1
+        },
+        "height": {
+            "type": "number",
+            "default": 300
+        },
+        "borderRadius": {
+            "type": "string",
+            "default": "0px"
+        }
+    },
+    "example": {},
+    "textdomain": "goodblocks",
+    "editorScript": "file:./index.js",
+    "editorStyle": "file:./index.css",
+    "style": "file:./style-index.css"
+}

--- a/src/blocks/media-grid/edit.js
+++ b/src/blocks/media-grid/edit.js
@@ -1,0 +1,270 @@
+import { __ } from '@wordpress/i18n';
+import {
+	useBlockProps,
+	useInnerBlocksProps,
+	InspectorControls
+} from '@wordpress/block-editor';
+import {
+	PanelBody,
+	RangeControl,
+	SelectControl,
+	Button,
+	Placeholder,
+	TextControl
+} from '@wordpress/components';
+import { useState, useEffect } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { createBlock } from '@wordpress/blocks';
+
+import './editor.scss';
+
+const LAYOUT_OPTIONS = [
+	{ label: __('Grid', 'goodblocks'), value: 'grid' },
+	{ label: __('Bento - Large Left', 'goodblocks'), value: 'bento-large-left' },
+	{ label: __('Bento - Large Right', 'goodblocks'), value: 'bento-large-right' },
+	{ label: __('Bento - Large Top', 'goodblocks'), value: 'bento-large-top' },
+	{ label: __('Mosaic', 'goodblocks'), value: 'mosaic' },
+	{ label: __('Custom', 'goodblocks'), value: 'custom' }
+];
+
+export default function Edit({ attributes, setAttributes, clientId }) {
+	const {
+		columns,
+		gap,
+		layout,
+		tabletColumns,
+		mobileColumns,
+		height,
+		borderRadius
+	} = attributes;
+
+	const [showTemplateSelector, setShowTemplateSelector] = useState(false);
+	const { replaceBlocks, updateBlockAttributes } = useDispatch('core/block-editor');
+	const innerBlocksClientIds = useSelect(
+		(select) => select('core/block-editor').getBlockOrder(clientId),
+		[clientId]
+	);
+	const innerBlocks = useSelect(
+		(select) => select('core/block-editor').getBlocks(clientId),
+		[clientId]
+	);
+
+	const getLargeItemSpan = (cols) => {
+		return Math.ceil(cols * 2 / 3) || 2;
+	};
+
+	const getLayoutAttributes = (layoutType, cols = 3) => {
+		const largeSpan = getLargeItemSpan(cols);
+		const clearAttrs = { gridColumn: undefined, gridRow: undefined };
+		switch (layoutType) {
+			case 'grid':
+			case 'mosaic':
+				return [clearAttrs, clearAttrs, clearAttrs, clearAttrs, clearAttrs, clearAttrs];
+			case 'bento-large-left':
+				return [
+					{ gridColumn: `span ${largeSpan}`, gridRow: `span ${largeSpan}` },
+					clearAttrs, clearAttrs, clearAttrs, clearAttrs, clearAttrs
+				];
+			case 'bento-large-right':
+				return [
+					clearAttrs, clearAttrs,
+					{ gridColumn: `${cols - largeSpan + 1} / ${cols + 1}`, gridRow: '1 / 3' },
+					clearAttrs, clearAttrs, clearAttrs
+				];
+			case 'bento-large-top':
+				return [
+					{ gridColumn: '1 / -1' },
+					clearAttrs, clearAttrs, clearAttrs
+				];
+			case 'custom':
+				return [];
+			default:
+				return [];
+		}
+	};
+
+	const getTemplate = (layoutType, cols = 3) => {
+		const largeSpan = getLargeItemSpan(cols);
+		switch (layoutType) {
+			case 'grid':
+				return [
+					['goodblocks/media-grid-item', { title: 'Item 1' }],
+					['goodblocks/media-grid-item', { title: 'Item 2' }],
+					['goodblocks/media-grid-item', { title: 'Item 3' }],
+					['goodblocks/media-grid-item', { title: 'Item 4' }],
+					['goodblocks/media-grid-item', { title: 'Item 5' }],
+					['goodblocks/media-grid-item', { title: 'Item 6' }]
+				];
+			case 'bento-large-left':
+				return [
+				['goodblocks/media-grid-item', { title: 'Large Item', gridColumn: `span ${largeSpan}`, gridRow: `span ${largeSpan}` }],
+					['goodblocks/media-grid-item', { title: 'Item 2' }],
+					['goodblocks/media-grid-item', { title: 'Item 3' }],
+					['goodblocks/media-grid-item', { title: 'Item 4' }],
+					['goodblocks/media-grid-item', { title: 'Item 5' }],
+					['goodblocks/media-grid-item', { title: 'Item 6' }]
+				];
+			case 'bento-large-right':
+				return [
+					['goodblocks/media-grid-item', { title: 'Item 1' }],
+					['goodblocks/media-grid-item', { title: 'Item 2' }],
+				['goodblocks/media-grid-item', { title: 'Large Item', gridColumn: `${cols - largeSpan + 1} / ${cols + 1}`, gridRow: '1 / 3' }],
+					['goodblocks/media-grid-item', { title: 'Item 4' }],
+					['goodblocks/media-grid-item', { title: 'Item 5' }],
+					['goodblocks/media-grid-item', { title: 'Item 6' }]
+				];
+			case 'bento-large-top':
+				return [
+					['goodblocks/media-grid-item', { title: 'Large Item', gridColumn: '1 / -1' }],
+					['goodblocks/media-grid-item', { title: 'Item 2' }],
+					['goodblocks/media-grid-item', { title: 'Item 3' }],
+					['goodblocks/media-grid-item', { title: 'Item 4' }],
+					['goodblocks/media-grid-item', { title: 'Item 5' }],
+					['goodblocks/media-grid-item', { title: 'Item 6' }],
+				];
+			case 'mosaic':
+				return [
+					['goodblocks/media-grid-item', { title: 'Item 1' }],
+					['goodblocks/media-grid-item', { title: 'Item 2' }],
+					['goodblocks/media-grid-item', { title: 'Item 3' }],
+					['goodblocks/media-grid-item', { title: 'Item 4' }],
+					['goodblocks/media-grid-item', { title: 'Item 5' }],
+					['goodblocks/media-grid-item', { title: 'Item 6' }]
+				];
+			case 'custom':
+				return [];
+			default:
+				return [];
+		}
+	};
+
+	useEffect(() => {
+		if (!layout) {
+			setShowTemplateSelector(true);
+		}
+	}, [layout]);
+
+	useEffect(() => {
+		if (layout === 'custom') {
+			return;
+		}
+
+		if (layout && innerBlocksClientIds.length > 0) {
+			const template = getTemplate(layout, columns);
+
+			if (innerBlocksClientIds.length !== template.length) {
+				const newBlocks = template.map(([blockName, blockAttrs]) =>
+					createBlock(blockName, blockAttrs)
+				);
+				replaceBlocks(innerBlocksClientIds, newBlocks);
+			} else {
+				const layoutAttrs = getLayoutAttributes(layout, columns);
+				innerBlocksClientIds.forEach((blockId, index) => {
+					if (layoutAttrs[index]) {
+						updateBlockAttributes(blockId, layoutAttrs[index]);
+					}
+				});
+			}
+		}
+	}, [layout, columns, innerBlocksClientIds, replaceBlocks, updateBlockAttributes]);
+
+	const blockProps = useBlockProps({
+		style: {
+			'--columns': columns.toString(),
+			'--gap': `${gap}px`,
+			'--item-height': `${height ?? 300}px`,
+			'--border-radius': borderRadius || '0px'
+		},
+		...(layout && { 'data-layout': layout })
+	});
+
+	const ALLOWED_BLOCKS = ['goodblocks/media-grid-item'];
+	const TEMPLATE = layout ? getTemplate(layout, columns) : [];
+
+	const innerBlocksProps = useInnerBlocksProps(blockProps, {
+		allowedBlocks: ALLOWED_BLOCKS,
+		template: TEMPLATE,
+		templateLock: false
+	});
+
+	const handleLayoutSelect = (selectedLayout) => {
+		setAttributes({ layout: selectedLayout });
+		setShowTemplateSelector(false);
+	};
+
+	return (
+		<>
+			{showTemplateSelector && (
+				<Placeholder
+					label={__('Media Grid', 'goodblocks')}
+					instructions={__('Select a layout to get started', 'goodblocks')}
+				>
+					<div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '10px', minWidth: '400px' }}>
+						{LAYOUT_OPTIONS.map((option) => (
+							<Button
+								key={option.value}
+								onClick={() => handleLayoutSelect(option.value)}
+								variant="secondary"
+								style={{ padding: '20px', textAlign: 'center' }}
+							>
+								{option.label}
+							</Button>
+						))}
+					</div>
+				</Placeholder>
+			)}
+
+			{layout && (
+				<InspectorControls>
+					<PanelBody title={__('Grid Settings', 'goodblocks')}>
+					<SelectControl
+						label={__('Layout Type', 'goodblocks')}
+						value={layout}
+						options={LAYOUT_OPTIONS}
+						onChange={(value) => setAttributes({ layout: value })}
+						help={__('Choose how items are arranged in the grid. Beware! Changing the layout here can remove existing media grid items.', 'goodblocks')}
+					/>
+
+					<RangeControl
+						label={__('Columns', 'goodblocks')}
+						value={columns}
+						onChange={(value) => setAttributes({ columns: value })}
+						min={1}
+						max={6}
+						help={__('Number of columns in the grid', 'goodblocks')}
+					/>
+
+					<RangeControl
+						label={__('Gap (px)', 'goodblocks')}
+						value={gap}
+						onChange={(value) => setAttributes({ gap: value })}
+						min={0}
+						max={50}
+						help={__('Space between grid items', 'goodblocks')}
+					/>
+
+					<RangeControl
+						label={__('Item Height (px)', 'goodblocks')}
+						value={height}
+						onChange={(value) => setAttributes({ height: value })}
+						min={100}
+						max={800}
+						step={10}
+						help={__('Minimum height of all grid items', 'goodblocks')}
+					/>
+
+					<TextControl
+						label={__('Border Radius', 'goodblocks')}
+						value={borderRadius}
+						onChange={(value) => setAttributes({ borderRadius: value })}
+						placeholder="0px"
+						help={__('E.g., 8px, 0.5rem, 50%', 'goodblocks')}
+					/>
+				</PanelBody>
+			</InspectorControls>
+			)}
+
+			<div {...innerBlocksProps} />
+		</>
+	);
+}

--- a/src/blocks/media-grid/editor.scss
+++ b/src/blocks/media-grid/editor.scss
@@ -1,0 +1,33 @@
+.wp-block-goodblocks-media-grid {
+	position: relative;
+
+	&::before {
+		content: '';
+		position: absolute;
+		top: -1px;
+		left: -1px;
+		right: -1px;
+		bottom: -1px;
+		border: 1px dashed #ccc;
+		pointer-events: none;
+		z-index: 1;
+	}
+
+	&.is-selected::before {
+		border-color: #007cba;
+	}
+
+	.wp-block-goodblocks-media-grid-item {
+		position: relative;
+		z-index: 2;
+	}
+
+	.is-mobile-preview & {
+		grid-template-columns: 1fr !important;
+
+		.wp-block-goodblocks-media-grid-item {
+			grid-column: 1 !important;
+			grid-row: auto !important;
+		}
+	}
+}

--- a/src/blocks/media-grid/index.js
+++ b/src/blocks/media-grid/index.js
@@ -1,0 +1,32 @@
+import { registerBlockType } from '@wordpress/blocks';
+import './style.scss';
+import Edit from './edit';
+import metadata from './block.json';
+import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+
+registerBlockType(metadata.name, {
+    edit: Edit,
+    save: ({ attributes }) => {
+        const {
+            columns,
+            gap,
+            layout,
+            height,
+            borderRadius
+        } = attributes;
+
+        const blockProps = useBlockProps.save({
+            'data-layout': layout,
+            style: {
+                '--columns': columns.toString(),
+                '--gap': `${gap}px`,
+                '--item-height': `${height ?? 300}px`,
+                '--border-radius': borderRadius ? `${borderRadius}` : '0px'
+            }
+        });
+
+        const innerBlocksProps = useInnerBlocksProps.save(blockProps);
+
+        return <div {...innerBlocksProps} />;
+    }
+});

--- a/src/blocks/media-grid/style.scss
+++ b/src/blocks/media-grid/style.scss
@@ -1,0 +1,46 @@
+.wp-block-goodblocks-media-grid {
+	margin-bottom: 0;
+	margin-top: 0;
+
+	& + & {
+		margin-top: 0;
+	}
+
+	display: grid;
+	gap: var(--gap, 20px);
+	grid-template-columns: repeat(var(--columns, 3), 1fr);
+	width: 100%;
+
+	@media (max-width: 768px) {
+		grid-template-columns: repeat(2, 1fr);
+	}
+
+	@media (max-width: 480px) {
+		grid-template-columns: repeat(1, 1fr);
+	}
+
+	&[data-layout="bento-large-top"] {
+		.wp-block-goodblocks-media-grid-item:first-child {
+			grid-column: 1 / -1;
+			grid-row: 1 / 2;
+		}
+	}
+
+	&[data-layout="mosaic"] {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+		auto-rows: var(--item-height, 250px);
+		gap: var(--gap, 20px);
+
+		.wp-block-goodblocks-media-grid-item {
+			&[style*="aspect-ratio"] {
+				auto-rows: auto;
+			}
+		}
+	}
+
+	.wp-block-goodblocks-media-grid-item {
+		margin: 0;
+		border-radius: var(--border-radius, 0px);
+	}
+}

--- a/src/blocks/media-grid/view.js
+++ b/src/blocks/media-grid/view.js
@@ -1,0 +1,140 @@
+/**
+ * Frontend script for Media Grid block
+ */
+
+document.addEventListener('DOMContentLoaded', function() {
+	const mediaGrids = document.querySelectorAll('.wp-block-goodblocks-media-grid');
+
+	mediaGrids.forEach(grid => {
+		initializeMediaGrid(grid);
+	});
+});
+
+function initializeMediaGrid(gridElement) {
+	const gridItems = gridElement.querySelectorAll('.wp-block-goodblocks-media-grid-item');
+
+	gridItems.forEach(item => {
+		initializeGridItem(item);
+	});
+}
+
+function initializeGridItem(item) {
+	const video = item.querySelector('video');
+
+	if (video) {
+		setupVideoInteraction(item, video);
+	}
+
+	setupClickInteraction(item);
+	setupIntersectionObserver(item);
+}
+
+function setupVideoInteraction(item, video) {
+	video.addEventListener('loadeddata', function() {
+		item.addEventListener('mouseenter', function() {
+			if (window.innerWidth > 768) {
+				video.play().catch(() => {});
+			}
+		});
+
+		item.addEventListener('mouseleave', function() {
+			if (window.innerWidth > 768) {
+				video.pause();
+				video.currentTime = 0;
+			}
+		});
+	});
+
+	item.addEventListener('click', function(e) {
+		if (window.innerWidth <= 768) {
+			e.preventDefault();
+
+			if (video.paused) {
+				pauseAllVideos(item.closest('.wp-block-goodblocks-media-grid'));
+				video.play().catch(() => {});
+			} else {
+				video.pause();
+			}
+		}
+	});
+}
+
+function setupClickInteraction(item) {
+	const title = item.querySelector('.item-title');
+
+	item.setAttribute('tabindex', '0');
+	item.setAttribute('role', 'button');
+
+	if (title) {
+		item.setAttribute('aria-label', title.textContent);
+	}
+
+	item.addEventListener('keydown', function(e) {
+		if (e.key === 'Enter' || e.key === ' ') {
+			e.preventDefault();
+			item.click();
+		}
+	});
+}
+
+function setupIntersectionObserver(item) {
+	const observer = new IntersectionObserver((entries) => {
+		entries.forEach(entry => {
+			const video = entry.target.querySelector('video');
+
+			if (video) {
+				if (entry.isIntersecting) {
+					video.load();
+				} else {
+					video.pause();
+					video.currentTime = 0;
+				}
+			}
+		});
+	}, {
+		threshold: 0.1,
+		rootMargin: '50px'
+	});
+
+	observer.observe(item);
+}
+
+function pauseAllVideos(gridContainer) {
+	if (!gridContainer) return;
+	const videos = gridContainer.querySelectorAll('video');
+	videos.forEach(video => {
+		video.pause();
+		video.currentTime = 0;
+	});
+}
+
+function handleResponsiveLayout() {
+	const mediaGrids = document.querySelectorAll('.wp-block-goodblocks-media-grid');
+
+	mediaGrids.forEach(grid => {
+		const items = grid.querySelectorAll('.wp-block-goodblocks-media-grid-item');
+
+		items.forEach(item => {
+			const video = item.querySelector('video');
+			if (video) {
+				if (window.innerWidth <= 768) {
+					video.removeAttribute('autoplay');
+				}
+			}
+		});
+	});
+}
+
+window.addEventListener('resize', debounce(handleResponsiveLayout, 250));
+
+function debounce(func, wait) {
+	let timeout;
+	return function executedFunction(...args) {
+		const later = () => {
+			clearTimeout(timeout);
+			func(...args);
+		};
+		clearTimeout(timeout);
+		timeout = setTimeout(later, wait);
+	};
+}

--- a/src/blocks/page-list/block.json
+++ b/src/blocks/page-list/block.json
@@ -1,0 +1,29 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "goodblocks/page-list",
+	"version": "0.1.0",
+	"title": "Page List",
+	"category": "widgets",
+	"icon": "editor-ul",
+	"description": "List pages like a sidebar menu.",
+	"example": {},
+	"supports": {
+		"html": false
+	},
+	"attributes": {
+		"parentPostId": {
+		  "type": "number",
+		  "default": 0
+		},
+		"showParent": {
+		  "type": "boolean",
+		  "default": true
+		}
+	},
+	"textdomain": "goodblocks",
+	"editorScript": "file:./index.js",
+	"editorStyle": "file:./index.css",
+	"style": "file:./style-index.css",
+	"render": "file:./render.php"
+}

--- a/src/blocks/page-list/edit.js
+++ b/src/blocks/page-list/edit.js
@@ -1,0 +1,41 @@
+import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
+import ServerSideRender from '@wordpress/server-side-render';
+import { __ } from '@wordpress/i18n';
+
+import './editor.scss';
+
+const Edit = ({ attributes, setAttributes }) => {
+    const { parentPostId, showParent } = attributes;
+
+    return (
+        <div {...useBlockProps()}>
+            <InspectorControls>
+                <PanelBody title={__('Settings', 'goodblocks')}>
+					<ToggleControl
+							label={__('Show parent', 'goodblocks')}
+							checked={!!showParent}
+							onChange={(newShowParent) => setAttributes({ showParent: newShowParent })}
+							value={showParent}
+					/>
+                    <TextControl
+							label={__('Parent post ID', 'goodblocks')}
+                        value={parentPostId}
+                        onChange={(value) => {
+							if (!isNaN(value)) {
+                                setAttributes({ parentPostId: value });
+                            }
+                        }}
+                        help={__('Leave empty (0) to show parent of current page.', 'goodblocks')}
+                    />
+                </PanelBody>
+            </InspectorControls>
+            <ServerSideRender
+                block="goodblocks/page-list"
+                attributes={attributes}
+            />
+        </div>
+    );
+};
+
+export default Edit;

--- a/src/blocks/page-list/editor.scss
+++ b/src/blocks/page-list/editor.scss
@@ -1,0 +1,5 @@
+.wp-block-goodblocks-page-list {
+	a {
+		pointer-events: none !important;
+	}
+}

--- a/src/blocks/page-list/index.js
+++ b/src/blocks/page-list/index.js
@@ -1,0 +1,8 @@
+import { registerBlockType } from '@wordpress/blocks';
+import './style.scss';
+import Edit from './edit';
+import metadata from './block.json';
+
+registerBlockType(metadata.name, {
+	edit: Edit,
+});

--- a/src/blocks/page-list/render.php
+++ b/src/blocks/page-list/render.php
@@ -1,0 +1,30 @@
+<?php
+$parent = ! empty( $attributes['parentPostId'] ) ? $attributes['parentPostId'] : get_the_ID();
+
+$highest_parent = $parent;
+while ( $highest_parent ) {
+	$parent_id = wp_get_post_parent_id( $highest_parent );
+	if ( ! $parent_id ) {
+		break;
+	}
+	$highest_parent = $parent_id;
+}
+
+$args = array(
+	'title_li'    => '',
+	'child_of'    => $highest_parent,
+	'sort_column' => 'menu_order,post_title',
+	'echo'        => false,
+);
+
+$pages = wp_list_pages( $args );
+?>
+<div <?php echo get_block_wrapper_attributes(); ?>>
+	<?php if ( $attributes['showParent'] ) : ?>
+		<h3 class="page-list-title"><a
+				href="<?php the_permalink( $highest_parent ); ?>"><?php echo get_the_title( $highest_parent ); ?></a></h3>
+	<?php endif; ?>
+	<ul class="page-list">
+		<?php echo $pages; ?>
+	</ul>
+</div>

--- a/src/blocks/page-list/style.scss
+++ b/src/blocks/page-list/style.scss
@@ -1,0 +1,31 @@
+.wp-block-goodblocks-page-list {
+	li {
+		list-style: none;
+	}
+
+	a {
+		text-decoration: none;
+	}
+
+	.page_item {
+		margin-bottom: 0.5em;
+	}
+
+	.children {
+		margin-top: 0.5em;
+	}
+
+	.current_page_item > a {
+		font-weight: bold;
+	}
+
+	.page-list {
+		padding-left: 0;
+	}
+
+	.page-list-title {
+		font-size: inherit;
+		line-height: inherit;
+		margin-bottom: 0.5em;
+	}
+}

--- a/src/blocks/quiz/block.json
+++ b/src/blocks/quiz/block.json
@@ -1,0 +1,75 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "goodblocks/quiz",
+	"version": "0.1.0",
+	"title": "Quiz",
+	"category": "goodblocks",
+	"icon": "smiley",
+	"description": "Interactive quiz question block.",
+	"example": {},
+	"supports": {
+		"html": false,
+		"align": [
+			"wide",
+			"full"
+		],
+		"color": {
+			"gradient": true
+		},
+		"spacing": {
+			"padding": true,
+			"margin": true
+		}
+	},
+	"attributes": {
+		"instanceId": {
+			"type": "string",
+			"default": ""
+		},
+		"question": {
+			"type": "string",
+			"default": "What is 2+2?"
+		},
+		"backgroundMedia": {
+			"type": "object",
+			"default": null
+		},
+		"align": {
+			"type": "string",
+			"default": "full"
+		},
+		"answers": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			},
+			"default": [
+				"-4",
+				"8",
+				"4"
+			]
+		},
+		"correctIndex": {
+			"type": "number",
+			"default": 2
+		},
+		"style": {
+			"type": "object",
+			"default": {
+				"spacing": {
+					"margin": {
+						"top": "3rem",
+						"bottom": "3rem"
+					}
+				}
+			}
+		}
+	},
+	"textdomain": "goodblocks",
+	"editorScript": "file:./index.js",
+	"editorStyle": "file:./index.css",
+	"style": "file:./style-index.css",
+	"render": "file:./render.php",
+	"viewScript": "file:./view.js"
+}

--- a/src/blocks/quiz/edit.js
+++ b/src/blocks/quiz/edit.js
@@ -1,0 +1,108 @@
+import { __, sprintf } from '@wordpress/i18n';
+import { useBlockProps, InspectorControls, MediaUpload, MediaUploadCheck } from '@wordpress/block-editor';
+import { PanelBody, TextControl, RadioControl, Button } from '@wordpress/components';
+
+const Edit = ({ attributes, setAttributes }) => {
+	const { question, answers, correctIndex, backgroundMedia } = attributes;
+
+	const updateQuestion = (newQuestion) => {
+		setAttributes({ question: newQuestion });
+	};
+
+	const updateAnswer = (index, newAnswer) => {
+		const updatedAnswers = [...answers];
+		updatedAnswers[index] = newAnswer;
+		setAttributes({ answers: updatedAnswers });
+	};
+
+	const updateCorrectIndex = (newIndex) => {
+		setAttributes({ correctIndex: parseInt(newIndex, 10) });
+	};
+
+	const ensureThreeAnswers = () => {
+		const updatedAnswers = [...answers];
+		while (updatedAnswers.length < 3) {
+			updatedAnswers.push('');
+		}
+		setAttributes({ answers: updatedAnswers });
+	};
+
+	if (!answers || answers.length < 3) {
+		ensureThreeAnswers();
+	}
+
+	const backgroundStyle = {};
+	if (backgroundMedia?.type === 'image' && backgroundMedia.url) {
+		backgroundStyle.backgroundImage = `url(${backgroundMedia.url})`;
+	}
+
+	const blockProps = useBlockProps({
+		style: backgroundStyle,
+	});
+
+	return (
+		<div {...blockProps}>
+			<InspectorControls>
+				<PanelBody title={__('Settings', 'goodblocks')} initialOpen={true}>
+					<RadioControl
+						label={__('Correct answer', 'goodblocks')}
+						help={__('Select correct answer', 'goodblocks')}
+						selected={correctIndex}
+						options={[
+							{ label: answers[0], value: 0 },
+							{ label: answers[1], value: 1 },
+							{ label: answers[2], value: 2 },
+						]}
+						onChange={updateCorrectIndex}
+					/>
+						<MediaUploadCheck>
+							<MediaUpload
+								onSelect={(media) => setAttributes({ backgroundMedia: media })}
+								allowedTypes={['image']}
+								render={({ open }) => (
+									<div>
+										{!!backgroundMedia && backgroundMedia.type === 'image' && (
+											<>
+												<img src={backgroundMedia.url} alt={backgroundMedia.alt} />
+												<Button
+													onClick={() => setAttributes({ backgroundMedia: null })}
+													isDestructive
+													isSecondary
+												>
+													{__('Remove image', 'goodblocks')}
+												</Button>
+											</>
+										)}
+										<Button onClick={open} isSecondary>
+											{!!backgroundMedia ? __('Change background image', 'goodblocks') : __('Add background image', 'goodblocks')}
+										</Button>
+									</div>
+								)}
+							/>
+						</MediaUploadCheck>
+				</PanelBody>
+			</InspectorControls>
+
+			<div class="question-quiz-container">
+				<TextControl
+					label={__('Question', 'goodblocks')}
+					value={question}
+					onChange={updateQuestion}
+					placeholder={__('Enter your question here', 'goodblocks')}
+				/>
+
+				{answers.map((answer, index) => (
+					<TextControl
+						key={index}
+						label={sprintf(__('Answer %d', 'goodblocks'), index + 1)}
+						value={answer}
+						onChange={(newAnswer) => updateAnswer(index, newAnswer)}
+						placeholder={sprintf(__('Answer %d here...', 'goodblocks'), index + 1)}
+					/>
+				))}
+			</div>
+		</div>
+	);
+};
+
+export default Edit;

--- a/src/blocks/quiz/editor.scss
+++ b/src/blocks/quiz/editor.scss
@@ -1,0 +1,7 @@
+.wp-block-goodblocks-quiz {
+	margin: 3rem 0;
+	display: flex;
+	flex-flow: column;
+	align-items: center;
+	justify-content: center;
+}

--- a/src/blocks/quiz/index.js
+++ b/src/blocks/quiz/index.js
@@ -1,0 +1,8 @@
+import { registerBlockType } from '@wordpress/blocks';
+import './style.scss';
+import Edit from './edit';
+import metadata from './block.json';
+
+registerBlockType(metadata.name, {
+    edit: Edit,
+});

--- a/src/blocks/quiz/render.php
+++ b/src/blocks/quiz/render.php
@@ -1,0 +1,46 @@
+<?php
+$question        = $attributes['question'] ?? '';
+$answers         = $attributes['answers'] ?? [];
+$correctIndex    = $attributes['correctIndex'] ?? null;
+$backgroundMedia = $attributes['backgroundMedia'] ?? null;
+$style           = '';
+
+if ( $backgroundMedia ) {
+	$style = "background-image: url(" . esc_url( $backgroundMedia['url'] ) . ");";
+}
+
+$uid      = uniqid();
+$block_id = 'quiz-' . $uid;
+
+if ( ! empty( $question ) && is_array( $answers ) && count( $answers ) === 3 && $correctIndex !== null ) :
+	?>
+	<div id="<?php echo esc_attr( $block_id ); ?>" <?php echo get_block_wrapper_attributes( array( 'style' => $style ) ); ?>>
+		<div class="question-quiz-container">
+			<div class="question-title">
+				<h2><?php echo esc_html( $question ); ?></h2>
+			</div>
+			<div class="question-block-answers">
+				<?php foreach ( $answers as $index => $answer ) : ?>
+					<div class="question show">
+						<div class="form-check">
+							<input type="radio" id="answer-<?php echo esc_attr( $uid . '-' . $index ); ?>"
+								name="answer-<?php echo esc_attr( $uid ); ?>" class="form-check-input"
+								value="<?php echo esc_attr( $index ); ?>" <?php echo $index === $correctIndex ? 'data-correct="true"' : ''; ?> />
+							<label for="answer-<?php echo esc_attr( $uid . '-' . $index ); ?>" class="form-check-label">
+								<?php echo esc_html( $answer ); ?>
+							</label>
+						</div>
+					</div>
+				<?php endforeach; ?>
+			</div>
+		</div>
+	</div>
+	<?php
+else :
+	?>
+	<div class="question-block__error">
+		<?php esc_html_e( 'Block is misconfigured.', 'goodblocks' ); ?>
+	</div>
+	<?php
+endif;
+?>

--- a/src/blocks/quiz/style.scss
+++ b/src/blocks/quiz/style.scss
@@ -1,0 +1,101 @@
+:root {
+	--correct_background: #fff;
+}
+
+.wp-block-goodblocks-quiz {
+	position: relative;
+	background-repeat: no-repeat;
+	background-size: cover;
+
+	.components-base-control {
+		width: 100%;
+	}
+
+	&.answered {
+		background: var(--correct_background) !important;
+	}
+
+	.question-quiz-container {
+		display: flex;
+		justify-content: center;
+		align-items: flex-start;
+		flex-flow: column;
+		height: 100%;
+		z-index: 3;
+		position: relative;
+		padding: 2rem;
+	}
+
+	.question-title {
+		margin-top: 0;
+	}
+
+	video {
+		width: 100%;
+		position: absolute;
+		top: 0;
+		left: 0;
+		height: 100%;
+		object-fit: cover;
+		z-index: 2;
+	}
+
+	.question {
+		width: 100%;
+
+		.form-check-input {
+			color: inherit;
+			border-color: currentColor;
+			margin-left: -1.5em;
+
+			&:disabled {
+				opacity: 1;
+			}
+		}
+
+		.form-check-input[disabled] ~ .form-check-label, .form-check-input:disabled ~ .form-check-label {
+			opacity: 1;
+		}
+
+		.form-check {
+			position: relative;
+		}
+
+		input[type="radio"] {
+			appearance: none;
+			-webkit-appearance: none;
+			-moz-appearance: none;
+			border-radius: 50%;
+			display: inline-block;
+			position: relative;
+		}
+
+		.correct-answer {
+			color: green;
+		}
+
+		.wrong-answer {
+			color: red;
+		}
+
+		.answer-icon {
+			position: absolute;
+			top: 0.25em;
+			left: 0;
+			background-repeat: no-repeat;
+			background-size: contain;
+		}
+
+		.answer-icon.wrong {
+			background-image: url("data:image/svg+xml,%3Csvg width='36' height='36' viewBox='0 0 36 36' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M2.5 2L34 33.5' stroke='%23D03933' stroke-width='4' stroke-linecap='round'/%3E%3Cpath d='M33.5 2L2 33.5' stroke='%23D03933' stroke-width='4' stroke-linecap='round'/%3E%3C/svg%3E%0A");
+			height: 1em;
+			width: 1em;
+		}
+
+		.answer-icon.correct {
+			background-image: url("data:image/svg+xml,%3Csvg width='34' height='45' viewBox='0 0 34 45' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M2 26L17.5965 41.5965C18.6748 42.6748 20.5148 42.198 20.9338 40.7318L32 2' stroke='%2319A87C' stroke-width='4' stroke-linecap='round'/%3E%3C/svg%3E%0A");
+			height: 1.4em;
+			width: 1em;
+		}
+	}
+}

--- a/src/blocks/quiz/view.js
+++ b/src/blocks/quiz/view.js
@@ -1,0 +1,55 @@
+document.addEventListener("DOMContentLoaded", function () {
+    document.querySelectorAll(".question-block-answers input[type='radio']").forEach(radio => {
+        radio.addEventListener("change", function () {
+            let parentDiv = this.closest(".form-check");
+
+            parentDiv.closest(".question-block-answers").querySelectorAll(".form-check").forEach(div => {
+                div.classList.remove("correct-answer", "wrong-answer");
+                let icon = div.querySelector(".answer-icon");
+                if (icon) {
+                    icon.remove();
+                }
+                let input = div.querySelector("input");
+                input.style.visibility = "visible";
+            });
+
+            let icon = document.createElement("span");
+            icon.classList.add("answer-icon");
+            if (this.dataset.correct === "true") {
+                icon.classList.add("correct");
+                let quizBlock = this.closest(".wp-block-goodblocks-quiz");
+                quizBlock.classList.add("answered");
+
+                let videoUrl = getComputedStyle(document.documentElement).getPropertyValue("--correct_background").trim();
+                let type = getComputedStyle(document.documentElement).getPropertyValue("--correct_type").trim();
+
+                if (type != "video") {
+                    return
+                }
+
+                let existingVideo = quizBlock.querySelector(".quiz-background-video");
+                if (existingVideo) {
+                    existingVideo.remove();
+                }
+
+                let video = document.createElement("video");
+                video.src = videoUrl;
+                video.classList.add("quiz-background-video");
+                video.autoplay = true;
+                video.loop = true;
+                video.muted = true;
+                video.playsInline = true;
+
+                quizBlock.appendChild(video);
+                quizBlock.querySelectorAll("input").forEach(input => {
+                    input.disabled = true;
+                });
+            } else {
+                icon.classList.add("wrong");
+            }
+
+            this.style.visibility = "hidden";
+            parentDiv.prepend(icon)
+        });
+    });
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,7 @@ const path = require('path');
 module.exports = {
 	...defaultConfig,
 	entry: {
+		// Existing blocks
 		'blocks/masonry-query/index': path.resolve(__dirname, 'src/blocks/masonry-query/index.js'),
 		'blocks/masonry-query/view': path.resolve(__dirname, 'src/blocks/masonry-query/view.js'),
 		'blocks/card-feature/index': path.resolve(__dirname, 'src/blocks/card-feature/index.js'),
@@ -15,6 +16,17 @@ module.exports = {
 		'blocks/search-autocomplete/view': path.resolve(__dirname, 'src/blocks/search-autocomplete/view.js'),
 		'blocks/image-compare/index': path.resolve(__dirname, 'src/blocks/image-compare/index.js'),
 		'blocks/image-compare/view': path.resolve(__dirname, 'src/blocks/image-compare/view.js'),
+		// Imported blocks
+		'blocks/countdown/index': path.resolve(__dirname, 'src/blocks/countdown/index.js'),
+		'blocks/countdown/view': path.resolve(__dirname, 'src/blocks/countdown/view.js'),
+		'blocks/quiz/index': path.resolve(__dirname, 'src/blocks/quiz/index.js'),
+		'blocks/quiz/view': path.resolve(__dirname, 'src/blocks/quiz/view.js'),
+		'blocks/page-list/index': path.resolve(__dirname, 'src/blocks/page-list/index.js'),
+		'blocks/double-container-text/index': path.resolve(__dirname, 'src/blocks/double-container-text/index.js'),
+		'blocks/media-grid/index': path.resolve(__dirname, 'src/blocks/media-grid/index.js'),
+		'blocks/media-grid/view': path.resolve(__dirname, 'src/blocks/media-grid/view.js'),
+		'blocks/media-grid-item/index': path.resolve(__dirname, 'src/blocks/media-grid-item/index.js'),
+		'blocks/mailchimp-signup/index': path.resolve(__dirname, 'src/blocks/mailchimp-signup/index.js'),
 	},
 	output: {
 		...defaultConfig.output,


### PR DESCRIPTION
## Summary
- Import 7 reusable Gutenberg blocks from the lorensbergs agoodblocks plugin, adapted to `goodblocks/*` namespace
- Add GitHub Actions workflows for CI (build verification) and Release (plugin zip on tags)

### Imported blocks
| Block | Description |
|-------|-------------|
| Countdown | Timer with animated number transitions |
| Quiz | Interactive question block with correct/wrong feedback |
| Page List | Hierarchical page navigation (sidebar menu) |
| Double Container Text | Two side-by-side media containers with overlays |
| Media Grid | Flexible bento/grid layout system |
| Media Grid Item | Individual item for Media Grid |
| Mailchimp Signup | Newsletter subscription form |

### Changes per block
- Namespace: `agoodblocks/*` / `agoodid/*` → `goodblocks/*`
- Text domain: `agoodgutenblock` / `agoodblocks` → `goodblocks`
- CSS classes: `.wp-block-agoodblocks-*` → `.wp-block-goodblocks-*`
- Webpack entries and PHP registration updated

### CI/CD
- **CI workflow**: builds on PR + push to main
- **Release workflow**: creates `goodblocks.zip` on version tags (`v*`)

## Test plan
- [ ] Run `npm run build` locally — all 11 blocks should compile
- [ ] Activate plugin in WordPress — all blocks appear in inserter under "GoodBlocks"
- [ ] Verify CI passes on this PR
- [ ] Test each imported block in the editor (insert, configure, save, view frontend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)