### PR TITLE
Add preliminary event status

### DIFF
--- a/goodblocks.php
+++ b/goodblocks.php
@@ -3,7 +3,7 @@
  * Plugin Name: GoodBlocks
  * Plugin URI: https://agoodsite.se
  * Description: Reusable Gutenberg blocks: Masonry Query, Post Grid, Search Autocomplete, Image Compare, Feature Card, Countdown, Quiz, Page List, Double Container, Media Grid, and Mailchimp Signup.
- * Version: 1.14.0-rc.2
+ * Version: 1.14.0-rc.3
  * Requires at least: 6.4
  * Requires PHP: 8.0
  * Author: AGoodId
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'GOODBLOCKS_VERSION', '1.14.0-rc.2' );
+define( 'GOODBLOCKS_VERSION', '1.14.0-rc.3' );
 define( 'GOODBLOCKS_DIR', plugin_dir_path( __FILE__ ) );
 define( 'GOODBLOCKS_URI', plugin_dir_url( __FILE__ ) );
 

--- a/inc/events-cpt.php
+++ b/inc/events-cpt.php
@@ -139,11 +139,12 @@ function goodblocks_event_detail_fields(): array {
 			'label'   => __( 'Status', 'goodblocks' ),
 			'type'    => 'select',
 			'options' => [
-				'scheduled' => __( 'Scheduled', 'goodblocks' ),
-				'changed'   => __( 'Changed', 'goodblocks' ),
-				'cancelled' => __( 'Cancelled', 'goodblocks' ),
-				'live'      => __( 'Live now', 'goodblocks' ),
-				'done'      => __( 'Done', 'goodblocks' ),
+				'scheduled'   => __( 'Scheduled', 'goodblocks' ),
+				'placeholder' => __( 'Preliminary / placeholder', 'goodblocks' ),
+				'changed'     => __( 'Changed', 'goodblocks' ),
+				'cancelled'   => __( 'Cancelled', 'goodblocks' ),
+				'live'        => __( 'Live now', 'goodblocks' ),
+				'done'        => __( 'Done', 'goodblocks' ),
 			],
 		],
 	];


### PR DESCRIPTION
Adds a native preliminary/placeholder event status so draft schedules can keep their public preliminary badge when editors open and save events.\n\nValidation:\n- php -l inc/events-cpt.php\n- php -l goodblocks.php