### PR TITLE
chore: bump GoodBlocks Instagram refresh release

### DIFF
--- a/goodblocks.php
+++ b/goodblocks.php
@@ -3,7 +3,7 @@
  * Plugin Name: GoodBlocks
  * Plugin URI: https://agoodsite.se
  * Description: Reusable Gutenberg blocks: Masonry Query, Post Grid, Search Autocomplete, Image Compare, Feature Card, Countdown, Quiz, Page List, Double Container, Media Grid, and Mailchimp Signup.
- * Version: 1.14.0-rc.4
+ * Version: 1.14.0-rc.5
  * Requires at least: 6.4
  * Requires PHP: 8.0
  * Author: AGoodId
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'GOODBLOCKS_VERSION', '1.14.0-rc.4' );
+define( 'GOODBLOCKS_VERSION', '1.14.0-rc.5' );
 define( 'GOODBLOCKS_DIR', plugin_dir_path( __FILE__ ) );
 define( 'GOODBLOCKS_URI', plugin_dir_url( __FILE__ ) );
 


### PR DESCRIPTION
## Summary\n- Bump GoodBlocks to 1.14.0-rc.5 so sites already reporting 1.14.0-rc.4 can receive the Instagram token refresh build.\n\n## Validation\n- php -l goodblocks.php\n- git diff --check