### PR TITLE
fix: bypass LiteSpeed lazyload for Instagram media

### DIFF
--- a/build/blocks/instagram-feed/render.php
+++ b/build/blocks/instagram-feed/render.php
@@ -55,6 +55,7 @@ $class = 'goodblocks-instagram-feed' . ( 'auto' === $aspect_ratio ? ' is-aspect-
 						class="goodblocks-instagram-feed__media"
 						src="<?php echo esc_url( $item['image_url'] ); ?>"
 						alt="<?php echo esc_attr( $alt ); ?>"
+						data-no-lazy="1"
 						loading="lazy"
 						decoding="async"
 					/>

--- a/src/blocks/instagram-feed/render.php
+++ b/src/blocks/instagram-feed/render.php
@@ -55,6 +55,7 @@ $class = 'goodblocks-instagram-feed' . ( 'auto' === $aspect_ratio ? ' is-aspect-
 						class="goodblocks-instagram-feed__media"
 						src="<?php echo esc_url( $item['image_url'] ); ?>"
 						alt="<?php echo esc_attr( $alt ); ?>"
+						data-no-lazy="1"
 						loading="lazy"
 						decoding="async"
 					/>


### PR DESCRIPTION
## Summary
- Prevent LiteSpeed Cache from rewriting GoodBlocks Instagram images to lazyload placeholders.

## Validation
- npm run build
- php -l for source and built render templates
- git diff --check

## Notes
- Required before the site grid can display images reliably.