### PR TITLE
perf: cacha popup-existens och popular search suggestions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -286,6 +286,63 @@ Likely future additions:
 
 Keep new event features compatible with the existing `goodblocks_event` CPT and meta fields unless there is a strong reason to migrate.
 
+## Riskytor och verifieringspolicy (dev-orchestrator)
+
+Denna sektion läses av den användarglobala dev-orchestrator-skillen för projektspecifika parametrar. Den har företräde framför skillens generiska defaults.
+
+### Riskytor
+
+GoodBlocks distribueras som en delad plugin till flera WordPress-sajter (via `GoodBlocks_GitHub_Updater`, se `inc/github-updater.php`) och auto-uppdateras på alla sajter som kör den när en `v*`-tag pushas. En trasig release har bred blast radius — den träffar alla konsument-sajter samtidigt, inte bara ett repo. Ändringar i följande kräver oberoende motbevisare (en separat subagent/modellkörning som aktivt försöker hitta fel, inte bara bekräftar) och den starkaste tillgängliga checker-modellen (Fable → Opus vid konflikt om budget):
+
+- `inc/github-updater.php` — auto-update-mekanismen. Fel här kan bryta uppdateringar eller leverera trasig kod till alla sajter.
+- `.github/workflows/ci.yml` och `.github/workflows/release.yml` — release-kedjan som paketerar och distribuerar `goodblocks.zip`.
+- REST-endpoints i `inc/search-rest-api.php`, `inc/masonry-rest-api.php` (permission_callback `__return_true`, dvs publikt nåbara utan auth) och `inc/agoodapp-sideload.php`, `inc/agoodapp-proxy.php` (kräver `edit_posts`/`upload_files` — verifiera att caps-checken faktiskt körs och inte kan kringgås).
+- Datamuterande vägar: CSV-import (`goodblocks_import_events_csv()` i `inc/events-cpt.php`) och WP-CLI-migreringen `wp goodblocks migrate-events` (`inc/events-migrate.php`), som skriver om `post_type` och meta i bulk. Kräv `--dry-run`-verifiering och validera att `goodblocks_get_events()`/virtuell recurrence-expansion (`_event_recurrence_*`-meta) inte kan producera oändliga eller felaktiga occurrence-listor.
+- `goodblocks.php` — huvudregistrering, versionskonstant (`GOODBLOCKS_VERSION`) och namespace-migreringslogik (`agoodsite-fse` → `agoodblocks` → `goodblocks`) som körs automatiskt vid aktivering/version-update.
+
+### Mänskliga gater
+
+- Ingen push till `main` utan PR-granskning (gäller även agenter — se "Branch-strategi"/"Releases" ovan).
+- Tagging (`git tag vX.Y.Z && git push --tags`) som triggar en publik release kräver explicit mänskligt godkännande — det är en distributionshändelse till produktionssajter, inte en vanlig commit.
+- Ändringar i `.github/workflows/` kräver mänsklig granskning innan merge (redan noterat under "Vad du inte ska göra").
+- Bulk-datamigrering (`wp goodblocks migrate-events` utan `--dry-run`) mot en produktionsdatabas kräver explicit mänskligt godkännande.
+
+### Modellpolicy
+
+- Implementation: standardmodell (Sonnet) för de flesta ändringar i block, PHP-helpers och templates.
+- Oberoende verifiering/motbevisare av riskytorna ovan: starkaste tillgängliga checker-modell (Fable, eller Opus om Fable inte är tillgänglig). Motbevisaren ska vara en separat körning/subagent från den som skrev ändringen, inte samma kontext.
+- Rutinmässig lint/formattering och dokumentationsuppdateringar: valfri modell, ingen oberoende granskning krävs.
+
+### Verifieringskommando
+
+```bash
+# PHP-syntax på ändrade filer
+php -l goodblocks.php
+php -l inc/events-cpt.php
+php -l inc/events-migrate.php
+php -l inc/github-updater.php
+
+# Lint (hela repot)
+npm run lint
+
+# Riktad lint för kända legacy-problemområden
+npx wp-scripts lint-js src/blocks/event-schedule src/blocks/event-now-next src/blocks/event-class-schedule
+npx wp-scripts lint-style 'src/blocks/event-schedule/**/*.scss' 'src/blocks/event-now-next/**/*.scss' 'src/blocks/event-class-schedule/**/*.scss'
+
+# Events-specifik smoke-test
+npm run test:events
+
+# Build och verifiera att build/ faktiskt ändrades för berörda block
+npm run build
+git status build/blocks/
+
+# Block-validering (samma check som CI kör)
+python3 -m json.tool src/blocks/<block>/block.json
+
+# Migrering: alltid dry-run först
+wp goodblocks migrate-events --dry-run
+```
+
 ## Pre-PR Checklist
 
 - Read `git status` before editing and before finishing.

--- a/inc/popup-cpt.php
+++ b/inc/popup-cpt.php
@@ -18,6 +18,8 @@ add_action( 'add_meta_boxes',                    'goodblocks_popup_add_meta_box'
 add_action( 'save_post_goodblocks_popup',        'goodblocks_popup_save_meta', 10, 2 );
 add_action( 'wp_footer',                         'goodblocks_render_popups' );
 add_action( 'wp_enqueue_scripts',                'goodblocks_popup_enqueue_assets' );
+add_action( 'transition_post_status',            'goodblocks_maybe_flush_popup_cache', 10, 3 );
+add_action( 'before_delete_post',                'goodblocks_flush_popup_cache_on_delete' );
 
 function goodblocks_register_popup_cpt(): void {
 	register_post_type( 'goodblocks_popup', [
@@ -129,6 +131,10 @@ function goodblocks_popup_save_meta( int $post_id, WP_Post $post ): void {
 }
 
 function goodblocks_render_popups(): void {
+	if ( ! goodblocks_has_popups() ) {
+		return;
+	}
+
 	$popups = get_posts( [
 		'post_type'      => 'goodblocks_popup',
 		'posts_per_page' => -1,
@@ -172,14 +178,7 @@ function goodblocks_render_popups(): void {
 }
 
 function goodblocks_popup_enqueue_assets(): void {
-	$has_popups = get_posts( [
-		'post_type'      => 'goodblocks_popup',
-		'posts_per_page' => 1,
-		'post_status'    => 'publish',
-		'fields'         => 'ids',
-	] );
-
-	if ( empty( $has_popups ) ) {
+	if ( ! goodblocks_has_popups() ) {
 		return;
 	}
 
@@ -200,4 +199,63 @@ function goodblocks_popup_enqueue_assets(): void {
 		[],
 		GOODBLOCKS_VERSION
 	);
+}
+
+/**
+ * Whether any published popup exists (cached).
+ *
+ * Both the footer renderer and the asset enqueue run on every front-end page.
+ * Without this, each would fire an uncached query on every request. The boolean
+ * is cached until a popup is published, unpublished, trashed or deleted.
+ */
+function goodblocks_has_popups(): bool {
+	$cached = get_transient( 'goodblocks_has_popups' );
+
+	if ( '1' === $cached || '0' === $cached ) {
+		return '1' === $cached;
+	}
+
+	$ids = get_posts( [
+		'post_type'      => 'goodblocks_popup',
+		'posts_per_page' => 1,
+		'post_status'    => 'publish',
+		'fields'         => 'ids',
+		'no_found_rows'  => true,
+	] );
+
+	$has = ! empty( $ids );
+	set_transient( 'goodblocks_has_popups', $has ? '1' : '0', DAY_IN_SECONDS );
+
+	return $has;
+}
+
+/**
+ * Clear the cached popup existence flag.
+ */
+function goodblocks_flush_popup_cache(): void {
+	delete_transient( 'goodblocks_has_popups' );
+}
+
+/**
+ * Flush the popup cache when a popup changes publish status.
+ *
+ * @param string  $new_status New post status.
+ * @param string  $old_status Old post status.
+ * @param WP_Post $post       Post object.
+ */
+function goodblocks_maybe_flush_popup_cache( $new_status, $old_status, $post ): void {
+	if ( isset( $post->post_type ) && 'goodblocks_popup' === $post->post_type ) {
+		goodblocks_flush_popup_cache();
+	}
+}
+
+/**
+ * Flush the popup cache when a popup is permanently deleted.
+ *
+ * @param int $post_id Post ID being deleted.
+ */
+function goodblocks_flush_popup_cache_on_delete( $post_id ): void {
+	if ( 'goodblocks_popup' === get_post_type( $post_id ) ) {
+		goodblocks_flush_popup_cache();
+	}
 }

--- a/inc/search-rest-api.php
+++ b/inc/search-rest-api.php
@@ -112,6 +112,18 @@ function goodblocks_search_suggestions_callback( WP_REST_Request $request ): WP_
 	$count  = min( $request->get_param( 'count' ), 20 );
 	$search = $request->get_param( 's' );
 
+	// The "popular" list (no search term) is identical for every visitor, so it
+	// can be cached. Search-specific suggestions are left uncached.
+	$cache_key = '';
+	if ( ! $search ) {
+		$cache_key = 'goodblocks_suggestions_popular_' . $count;
+		$cached    = get_transient( $cache_key );
+
+		if ( is_array( $cached ) ) {
+			return new WP_REST_Response( $cached, 200 );
+		}
+	}
+
 	$args = [
 		'post_type'      => [ 'post', 'page' ],
 		'post_status'    => 'publish',
@@ -143,6 +155,13 @@ function goodblocks_search_suggestions_callback( WP_REST_Request $request ): WP_
 	}
 
 	wp_reset_postdata();
+
+	if ( $cache_key ) {
+		$ttl = (int) apply_filters( 'goodblocks_suggestions_cache_ttl', 15 * MINUTE_IN_SECONDS );
+		if ( $ttl > 0 ) {
+			set_transient( $cache_key, $results, $ttl );
+		}
+	}
 
 	return new WP_REST_Response( $results, 200 );
 }


### PR DESCRIPTION
Prestandafixar inspirerade av [Simple Historys performance-artikel](https://simple-history.com/2026/simple-history-performance/) — principen "kör inga onödiga queries på frontend". Isolerad från pågående WIP; rör **inte** event-/local-navigation-/form-arbetet.

## Vad som ändras

**#2 — Popup: två ocachade queries/sidladdning → noll (på sajter utan popups)**
`goodblocks_render_popups` (wp_footer) och `goodblocks_popup_enqueue_assets` (wp_enqueue_scripts) körde varsin `get_posts()` på *varje* frontend-request bara för att kolla om någon popup finns. Ny delad, cachad boolean `goodblocks_has_popups()` (transient) kortsluter båda. Invalideras vid `transition_post_status` och `before_delete_post` för popup-CPT:n.
- Sajt utan popups: 2 queries/sida → 0
- Sajt med popups: 2 → 1 (den nödvändiga render-queryn kvarstår)

**#3 — Search: cacha "popular suggestions"**
`/goodblocks/v1/search/suggestions` utan sökterm ger en lista (`orderby comment_count`) som är identisk för alla besökare, men kördes som färsk `WP_Query` per anrop. Cachas nu i transient med filtrerbar TTL (`goodblocks_suggestions_cache_ttl`, default 15 min). Sökspecifika suggestions lämnas ocachade.

## Medvetet **inte** med i denna PR

- **(a) `goodblocks_get_events`-cache** — den tunga, obegränsade (`posts_per_page => -1`) recurrence-expansionen finns bara i pågående WIP, inte i `main`. Att cacha main-versionen (redan bounded) vore låg effekt och skulle krocka med det pågående event-arbetet. Görs bäst *ovanpå* recurrence-koden när den committats.
- **#4 asset-loading** — den globala local-navigation-enqueuen behövs av den nya `[goodblocks_local_navigation]`-shortcoden (renderas utanför block-pipelinen). Att ta bort den skulle bryta shortcoden. Skippas.

## Verifiering
- `php -l` rent på båda filerna.
- Ingen ändring i `build/` (endast PHP).
- Transient-invalidering täcker publicera/avpublicera/papperskorg/permanent radering av popups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)