### PR TITLE
fix: restore event details in post grid lists

### DIFF
--- a/build/blocks/post-grid/templates/list.php
+++ b/build/blocks/post-grid/templates/list.php
@@ -13,10 +13,15 @@ $event               = $is_goodblocks_event ? goodblocks_get_event_data( get_the
 ?>
 <div class="list-item">
 
-	<?php if ( $attributes['showFeaturedImage'] && has_post_thumbnail() ) : ?>
+	<?php
+	$thumbnail = ! empty( $attributes['showFeaturedImage'] )
+		? goodblocks_get_thumbnail( 'large', array(), $attributes['imageSource'] ?? 'featured' )
+		: '';
+	?>
+	<?php if ( $thumbnail ) : ?>
 		<a href="<?php the_permalink(); ?>" class="post-thumbnail"
 			style="aspect-ratio: <?php echo esc_attr( $attributes['aspectRatio'] ); ?>;">
-			<?php echo goodblocks_get_thumbnail( 'large' ); ?>
+			<?php echo $thumbnail; ?>
 		</a>
 	<?php endif; ?>
 

--- a/goodblocks.php
+++ b/goodblocks.php
@@ -3,7 +3,7 @@
  * Plugin Name: GoodBlocks
  * Plugin URI: https://agoodsite.se
  * Description: Reusable Gutenberg blocks: Masonry Query, Post Grid, Search Autocomplete, Image Compare, Feature Card, Countdown, Quiz, Page List, Double Container, Media Grid, and Mailchimp Signup.
- * Version: 1.14.0-rc.22
+ * Version: 1.14.0-rc.24
  * Requires at least: 6.4
  * Requires PHP: 8.0
  * Author: AGoodId
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'GOODBLOCKS_VERSION', '1.14.0-rc.22' );
+define( 'GOODBLOCKS_VERSION', '1.14.0-rc.24' );
 define( 'GOODBLOCKS_DIR', plugin_dir_path( __FILE__ ) );
 define( 'GOODBLOCKS_URI', plugin_dir_url( __FILE__ ) );
 

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -56,6 +56,19 @@ function goodblocks_get_thumbnail( $size = 'large', $attr = array(), $source = '
 		return wp_get_attachment_image( $default_image, $size );
 	}
 
+	$legacy_default_image = apply_filters( 'pt_cv_default_image', '' );
+
+	if ( is_string( $legacy_default_image ) && $legacy_default_image ) {
+		$src = esc_url( $legacy_default_image );
+		if ( $src ) {
+			return sprintf(
+				'<img src="%1$s" alt="%2$s" loading="lazy" decoding="async" />',
+				$src,
+				esc_attr( get_the_title( $post ) )
+			);
+		}
+	}
+
 	return '';
 }
 
@@ -82,6 +95,60 @@ function goodblocks_get_trimmed_excerpt( $word_count = 35 ) {
 
 	return preg_replace( '/[.!?]\s+…$/u', ' …', $excerpt );
 }
+
+/**
+ * Display an event date range for legacy The Events Calendar events.
+ *
+ * @param int|null $event_id Event post ID.
+ */
+function goodblocks_display_tribe_event_date_range( $event_id = null ) {
+	if ( ! function_exists( 'tribe_get_start_date' ) ) {
+		return;
+	}
+
+	$event_id = $event_id ? absint( $event_id ) : get_the_ID();
+	if ( ! $event_id ) {
+		return;
+	}
+
+	$is_all_day = function_exists( 'tribe_event_is_all_day' ) && tribe_event_is_all_day( $event_id );
+	$current_year = date_i18n( 'Y' );
+	$date_format  = 'j F';
+	$time_format  = ' H.i';
+
+	$start_date = tribe_get_start_date( $event_id, false, 'Y-m-d' );
+	$end_date   = tribe_get_end_date( $event_id, false, 'Y-m-d' );
+	$start_year = date( 'Y', strtotime( $start_date ) );
+	$end_year   = date( 'Y', strtotime( $end_date ) );
+
+	$start_format = $date_format;
+	if ( $start_year !== $current_year ) {
+		$start_format .= ' Y';
+	}
+	if ( ! $is_all_day ) {
+		$start_format .= $time_format;
+	}
+
+	$end_format = $date_format;
+	if ( $end_year !== $current_year ) {
+		$end_format .= ' Y';
+	}
+	if ( ! $is_all_day ) {
+		$end_format .= $time_format;
+	}
+
+	$start    = tribe_get_start_date( $event_id, false, $start_format );
+	$end      = tribe_get_end_date( $event_id, false, $end_format );
+	$end_time = function_exists( 'tribe_get_end_time' ) ? tribe_get_end_time( $event_id, 'H.i' ) : '';
+
+	if ( $start_date === $end_date ) {
+		echo esc_html( $is_all_day || ! $end_time ? $start : sprintf( '%s-%s', $start, $end_time ) );
+		return;
+	}
+
+	echo esc_html( sprintf( '%s-%s', $start, $end ) );
+}
+add_action( 'goodblocks_event_date_range', 'goodblocks_display_tribe_event_date_range', 10, 1 );
 
 /**
  * Load a block template with theme override support.

--- a/src/blocks/post-grid/templates/list.php
+++ b/src/blocks/post-grid/templates/list.php
@@ -13,10 +13,15 @@ $event               = $is_goodblocks_event ? goodblocks_get_event_data( get_the
 ?>
 <div class="list-item">
 
-	<?php if ( $attributes['showFeaturedImage'] && has_post_thumbnail() ) : ?>
+	<?php
+	$thumbnail = ! empty( $attributes['showFeaturedImage'] )
+		? goodblocks_get_thumbnail( 'large', array(), $attributes['imageSource'] ?? 'featured' )
+		: '';
+	?>
+	<?php if ( $thumbnail ) : ?>
 		<a href="<?php the_permalink(); ?>" class="post-thumbnail"
 			style="aspect-ratio: <?php echo esc_attr( $attributes['aspectRatio'] ); ?>;">
-			<?php echo goodblocks_get_thumbnail( 'large' ); ?>
+			<?php echo $thumbnail; ?>
 		</a>
 	<?php endif; ?>
 


### PR DESCRIPTION
## Summary
- render fallback thumbnails in Post Grid list layout, matching grid layout behavior
- add The Events Calendar date-range rendering for legacy tribe_events
- bump GoodBlocks to 1.14.0-rc.24

## Verification
- php -l goodblocks.php
- php -l inc/helpers.php
- php -l src/blocks/post-grid/templates/list.php
- php -l build/blocks/post-grid/templates/list.php
- verified frisbeesport.se homepage calendar: 4 items, dates present, thumbnails present, no image underline