### PR TITLE
fix: skip svg thumbnails in post grids

### DIFF
--- a/goodblocks.php
+++ b/goodblocks.php
@@ -3,7 +3,7 @@
  * Plugin Name: GoodBlocks
  * Plugin URI: https://agoodsite.se
  * Description: Reusable Gutenberg blocks: Masonry Query, Post Grid, Search Autocomplete, Image Compare, Feature Card, Countdown, Quiz, Page List, Double Container, Media Grid, and Mailchimp Signup.
- * Version: 1.14.0-rc.24
+ * Version: 1.14.0-rc.26
  * Requires at least: 6.4
  * Requires PHP: 8.0
  * Author: AGoodId
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'GOODBLOCKS_VERSION', '1.14.0-rc.24' );
+define( 'GOODBLOCKS_VERSION', '1.14.0-rc.26' );
 define( 'GOODBLOCKS_DIR', plugin_dir_path( __FILE__ ) );
 define( 'GOODBLOCKS_URI', plugin_dir_url( __FILE__ ) );
 

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -20,15 +20,20 @@ if ( ! defined( 'ABSPATH' ) ) {
 function goodblocks_get_thumbnail( $size = 'large', $attr = array(), $source = 'featured' ) {
 	$post = get_post();
 
-	if ( 'first' !== $source && has_post_thumbnail( $post ) ) {
-		return get_the_post_thumbnail( $post, $size, $attr );
+	if ( 'first' !== $source ) {
+		$thumbnail = goodblocks_get_post_thumbnail_html( $post, $size, $attr );
+		if ( $thumbnail ) {
+			return $thumbnail;
+		}
 	}
 
 	if ( 'first' === $source ) {
 		$content = get_the_content( null, false, $post );
 
 		if ( preg_match( '/wp-image-(\d+)/', $content, $image_id ) ) {
-			$image = wp_get_attachment_image( absint( $image_id[1] ), $size, false, $attr );
+			$attachment_id = absint( $image_id[1] );
+			$mime_type     = get_post_mime_type( $attachment_id );
+			$image         = 'image/svg+xml' !== $mime_type ? wp_get_attachment_image( $attachment_id, $size, false, $attr ) : '';
 			if ( $image ) {
 				return $image;
 			}
@@ -36,7 +41,8 @@ function goodblocks_get_thumbnail( $size = 'large', $attr = array(), $source = '
 
 		if ( preg_match( '/<img[^>]+src=["\']([^"\']+)["\']/', $content, $matches ) ) {
 			$src = esc_url( $matches[1] );
-			if ( $src ) {
+			$path = wp_parse_url( $src, PHP_URL_PATH );
+			if ( $src && 'svg' !== strtolower( pathinfo( (string) $path, PATHINFO_EXTENSION ) ) ) {
 				return sprintf(
 					'<img src="%1$s" alt="%2$s" loading="lazy" decoding="async" />',
 					$src,
@@ -45,8 +51,9 @@ function goodblocks_get_thumbnail( $size = 'large', $attr = array(), $source = '
 			}
 		}
 
-		if ( has_post_thumbnail( $post ) ) {
-			return get_the_post_thumbnail( $post, $size, $attr );
+		$thumbnail = goodblocks_get_post_thumbnail_html( $post, $size, $attr );
+		if ( $thumbnail ) {
+			return $thumbnail;
 		}
 	}
 
@@ -70,6 +77,28 @@ function goodblocks_get_thumbnail( $size = 'large', $attr = array(), $source = '
 	}
 
 	return '';
+}
+
+/**
+ * Get a featured image only when it is suitable for thumbnail contexts.
+ *
+ * @param WP_Post|int|null $post Post object or ID.
+ * @param string           $size Image size.
+ * @param array            $attr Image attributes.
+ * @return string Image HTML.
+ */
+function goodblocks_get_post_thumbnail_html( $post, $size = 'large', $attr = array() ) {
+	if ( ! has_post_thumbnail( $post ) ) {
+		return '';
+	}
+
+	$thumbnail_id = get_post_thumbnail_id( $post );
+
+	if ( $thumbnail_id && 'image/svg+xml' === get_post_mime_type( $thumbnail_id ) ) {
+		return '';
+	}
+
+	return get_the_post_thumbnail( $post, $size, $attr );
 }
 
 /**


### PR DESCRIPTION
## Summary
- skip SVG attachments when GoodBlocks selects a featured thumbnail
- skip SVG content images when Post Grid uses the first content image source
- bump GoodBlocks to 1.14.0-rc.26

## Verification
- php -l inc/helpers.php
- php -l goodblocks.php
- uploaded 1.14.0-rc.26 to frisbeesport.se
- verified the front page calendar no longer uses the SVG logo for Styrelsemöte and all visible calendar images load