### PR TITLE
fix: package release zip with plugin root

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,11 +26,11 @@ jobs:
 
       - name: Create plugin zip
         run: |
-          mkdir -p dist
-          zip -r dist/goodblocks.zip \
-            goodblocks.php \
-            inc/ \
-            build/ \
+          mkdir -p dist/goodblocks
+          cp -R goodblocks.php inc build dist/goodblocks/
+          cd dist
+          zip -r goodblocks.zip \
+            goodblocks/ \
             -x "*.DS_Store"
 
       - name: Create GitHub Release


### PR DESCRIPTION
## Summary\n- package release zip with a top-level goodblocks/ directory\n- prevents WordPress plugin updates from losing the plugin folder\n\n## Testing\n- created local git archive with goodblocks/ prefix for manual recovery